### PR TITLE
Made the submission timestamp a parameter (was hard-coded)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
             <artifactId>fedora-client-messaging</artifactId>
             <version>0.7</version>
         </dependency>
+        <dependency>
+            <!-- Necessary to get rid of jodatime warnings about missing FromString
+                (Jodatime is a transitive dependency through yourmediashelf)  -->
+            <groupId>org.joda</groupId>
+            <artifactId>joda-convert</artifactId>
+            <version>1.6</version>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>src/main/scala</sourceDirectory>

--- a/src/main/assembly/dist/bin/easy-stage-dataset
+++ b/src/main/assembly/dist/bin/easy-stage-dataset
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 java -Dlogback.configurationFile=$EASY_STAGE_DATASET_HOME/cfg/logback.xml \
-     -Dconfig.file=$EASY_STAGE_DATASET_HOME/cfg/application.conf \
      -jar $EASY_STAGE_DATASET_HOME/bin/easy-stage-dataset.jar $@

--- a/src/main/scala/nl/knaw/dans/easy/stage/AMD.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/AMD.scala
@@ -4,6 +4,7 @@ import java.io.File
 
 import nl.knaw.dans.easy.stage.Constants._
 import nl.knaw.dans.easy.stage.Util._
+import org.joda.time.DateTime
 
 import scala.util.Try
 import scala.xml.Elem
@@ -11,19 +12,25 @@ import scala.xml.Elem
 object AMD {
 
   def create(sdoDir: File)(implicit s: Settings): Try[Unit] =
-    writeToFile(new File(sdoDir.getPath, AMD_FILENAME), AMD(s.ownerId, "2015-07-09T10:38:24.570+02:00").toString())
+    writeToFile(new File(sdoDir.getPath, AMD_FILENAME), AMD(s.ownerId, s.submissionTimestamp).toString())
 
-  def apply(depositorId: String, submissionDate: String): Elem = {
+  /*
+   * An exact timestamp is required, so valid ISO dates like 2015-09-01T12:01 won't do
+   */
+  def normalizeTimestamp (t: String): String = DateTime.parse(t).toString
+
+  def apply(depositorId: String, submissionTimestamp: String): Elem = {
+    val normalizedSubmissiontimestamp = normalizeTimestamp(submissionTimestamp)
     <damd:administrative-md xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" version="0.1">
       <datasetState>SUBMITTED</datasetState>
       <previousState>DRAFT</previousState>
-      <lastStateChange>{submissionDate}</lastStateChange>
+      <lastStateChange>{normalizedSubmissiontimestamp}</lastStateChange>
       <depositorId>{depositorId}</depositorId>
       <stateChangeDates>
         <damd:stateChangeDate>
           <fromState>DRAFT</fromState>
           <toState>SUBMITTED</toState>
-          <changeDate>{submissionDate}</changeDate>
+          <changeDate>{normalizedSubmissiontimestamp}</changeDate>
         </damd:stateChangeDate>
       </stateChangeDates>
       <groupIds></groupIds>

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -2,23 +2,29 @@ package nl.knaw.dans.easy.stage
 
 import java.io.File
 
+import org.joda.time.DateTime
 import org.rogach.scallop.ScallopConf
 
 class Conf(args: Seq[String]) extends ScallopConf(args) {
-  printedName = "easy-ingest"
+  printedName = "easy-state-dataset"
   version(s"$printedName ${Version()}")
   banner("""
            |Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x Repository.
            |
-           |Usage: easy-stage-dataset  <EASY-bag> <staged-digital-object-set> <urn>
+           |Usage: easy-stage-dataset  <EASY-bag> <staged-digital-object-set> <urn> <submission-timestamp>
            |Options:
            |""".stripMargin)
 
   val bag = trailArg[File](
     name = "EASY-bag",
-    descr = "The directory in EASY-BagIt format to be staged for ingest in Fedora",
+    descr = "Bag with extra metadata for EASY to be staged for ingest into Fedora",
     required = true)
-  val sdoSet = trailArg[File](
+  /*
+   * Scallop fails with a vague error if a type File argument refers to a file that does
+   * not (yet) exist. As the SDO-set might not yet exist we work around this by making
+   * this a type String argument
+   */
+  val sdoSet = trailArg[String](
     name = "staged-digital-object-set",
     descr = "The resulting Staged Digital Object directory (will be created if it does not exist)",
     required = true)
@@ -26,4 +32,19 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
     name = "urn",
     descr = "The URN to assign tot the new dataset in EASY",
     required = true)
+  val submissionTimestamp = trailArg[String](
+    name = "submission-timestamp",
+    descr = "Timestamp in ISO8601 format",
+    required = true
+  )
+  validateOpt(submissionTimestamp) {
+    case Some(t) =>
+      try {
+        DateTime.parse(t)
+        Right(Unit)
+      } catch {
+        case e: IllegalArgumentException => Left(s"Not a valid ISO8601 date: $t. Error: ${e.getMessage}")
+      }
+    case _ => Left("Could not parse argument submission-timestamp ")
+  }
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/JSON.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/JSON.scala
@@ -23,17 +23,17 @@ object JSON {
         ("contentFile" -> "AMD") ~
         ("dsID" -> "AMD") ~
         ("controlGroup" -> "X") ~
-        ("mimeType" -> "application/xml")
+        ("mimeType" -> "text/xml")
         ,
         ("contentFile" -> "EMD") ~
         ("dsID" -> "EMD") ~
         ("controlGroup" -> "X") ~
-        ("mimeType" -> "application/xml")
+        ("mimeType" -> "text/xml")
         ,
         ("contentFile" -> "PRSQL") ~
         ("dsID" -> "PRSQL") ~
         ("controlGroup" -> "X") ~
-        ("mimeType" -> "application/xml")
+        ("mimeType" -> "text/xml")
       )) ~
       ("relations" -> (List(
         ("predicate" -> HAS_DOI) ~ ("object" -> s.DOI) ~ ("isLiteral" -> true),
@@ -65,7 +65,7 @@ object JSON {
         ("contentFile" -> "EASY_FILE_METADATA") ~
         ("dsID" -> "EASY_FILE_METADATA") ~
         ("controlGroup" -> "X") ~
-        ("mimeType" -> "application/xml"))) ~
+        ("mimeType" -> "text/xml"))) ~
       ("relations" -> List(
         ("predicate" -> IS_MEMBER_OF) ~ ("objectSDO" -> parentSDO),
         ("predicate" -> IS_SUBORDINATE_TO) ~ ("objectSDO" -> DATASET_SDO),
@@ -82,7 +82,7 @@ object JSON {
         ("contentFile" -> "EASY_ITEM_CONTAINER_MD") ~
         ("dsID" -> "EASY_ITEM_CONTAINER_MD") ~
         ("controlGroup" -> "X") ~
-        ("mimeType" -> "application/xml"))) ~
+        ("mimeType" -> "text/xml"))) ~
       ("relations" -> List(
         ("predicate" -> IS_MEMBER_OF) ~ ("objectSDO" -> parentSDO),
         ("predicate" -> IS_SUBORDINATE_TO) ~ ("objectSDO" -> DATASET_SDO),

--- a/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
@@ -2,8 +2,10 @@ package nl.knaw.dans.easy.stage
 
 import java.io.File
 import java.net.URL
+import java.util.Date
 
 case class Settings(ownerId: String,
+                    submissionTimestamp: String,
                     bagStorageLocation: String,
                     bagitDir: File,
                     sdoSetDir: File,


### PR DESCRIPTION
Also:
- replaced application/xml with text/xml as the MIME type for XML datastreams. Fedora Admin chokes on the former.
- fixed wrong printed name in command line args
- removed reference to config file from shell script (is not used anymore)
- improved logging levels (everything was debug, made some high-level events info)
