### PR TITLE
no more trailArgs for clearer error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SYNOPSIS
 --------
 
     easy-stage-dataset -t <submission-timestamp> -u <urn> -d <doi> [ -o ] \
-                       -b <EASY-bag> -s <staged-digital-object-set>
+                          <EASY-bag> <staged-digital-object-set>
 
 DESCRIPTION
 -----------
@@ -31,20 +31,20 @@ The results of steps 1-3 can be ingested into the EASY Fedora Commons Repository
 ARGUMENTS
 ---------
 
-    -d, --doi  <arg>                         The DOI to assign to the new dataset in
-                                             EASY
-    -o, --doi-is-other-access-doi            Stage the provided DOI as an "other
-                                             access DOI"
-    -b, --EASY-bag  <arg>                    Bag with extra metadata for EASY to be
-                                             staged for ingest into Fedora
-    -s, --staged-digital-object-set  <arg>   The resulting Staged Digital Object
-                                             directory (will be created if it does
-                                             not exist)
-    -t, --submission-timestamp  <arg>        Timestamp in ISO8601 format
-    -u, --urn  <arg>                         The URN to assign to the new dataset in
-                                             EASY
-        --help                               Show help message
-        --version                            Show version of this program
+     -d, --doi  <arg>                    The DOI to assign to the new dataset in EASY
+     -o, --doi-is-other-access-doi       Stage the provided DOI as an "other access
+                                         DOI"
+     -t, --submission-timestamp  <arg>   Timestamp in ISO8601 format
+     -u, --urn  <arg>                    The URN to assign to the new dataset in EASY
+         --help                          Show help message
+         --version                       Show version of this program
+   
+    trailing arguments:
+     EASY-bag (required)                    Bag with extra metadata for EASY to be
+                                            staged for ingest into Fedora
+     staged-digital-object-set (required)   The resulting Staged Digital Object
+                                            directory (will be created if it does not
+                                            exist)
 
 INSTALLATION AND CONFIGURATION
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SYNOPSIS
 --------
 
     easy-stage-dataset -t <submission-timestamp> -u <urn> -d <doi> [ -o ] \
-                   <EASY-bag> <staged-digital-object-set>
+                       -b <EASY-bag> -s <staged-digital-object-set>
 
 DESCRIPTION
 -----------
@@ -31,20 +31,20 @@ The results of steps 1-3 can be ingested into the EASY Fedora Commons Repository
 ARGUMENTS
 ---------
 
-    -d, --doi  <arg>                    The DOI to assign to the new dataset in EASY
-    -o, --doi-is-other-access-doi       Stage the provided DOI as an "other access
-                                        DOI"
-    -t, --submission-timestamp  <arg>   Timestamp in ISO8601 format
-    -u, --urn  <arg>                    The URN to assign to the new dataset in EASY
-        --help                          Show help message
-        --version                       Show version of this program
-    
-    trailing arguments:
-     EASY-bag (required)                    Bag with extra metadata for EASY to be
-                                            staged for ingest into Fedora
-     staged-digital-object-set (required)   The resulting Staged Digital Object
-                                            directory (will be created if it does not
-                                            exist)
+    -d, --doi  <arg>                         The DOI to assign to the new dataset in
+                                             EASY
+    -o, --doi-is-other-access-doi            Stage the provided DOI as an "other
+                                             access DOI"
+    -b, --EASY-bag  <arg>                    Bag with extra metadata for EASY to be
+                                             staged for ingest into Fedora
+    -s, --staged-digital-object-set  <arg>   The resulting Staged Digital Object
+                                             directory (will be created if it does
+                                             not exist)
+    -t, --submission-timestamp  <arg>        Timestamp in ISO8601 format
+    -u, --urn  <arg>                         The URN to assign to the new dataset in
+                                             EASY
+        --help                               Show help message
+        --version                            Show version of this program
 
 INSTALLATION AND CONFIGURATION
 ------------------------------

--- a/src/main/assembly/dist/bin/easy-stage-file-item
+++ b/src/main/assembly/dist/bin/easy-stage-file-item
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+BINPATH=`readlink -f $0`
+if [ $? -ne 0 ] ; then
+  APPHOME=`dirname \`dirname $0 \``
+else
+  APPHOME=`dirname \`dirname $BINPATH \``
+fi
+
+java -Dlogback.configurationFile=$APPHOME/cfg/logback.xml \
+     -Dapp.home=$APPHOME \
+     -cp $APPHOME/bin/easy-stage-dataset.jar \
+     nl.knaw.dans.easy.stage.EasyStageFileItem $@

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -8,6 +8,7 @@ import org.rogach.scallop.{singleArgConverter, ValueConverter, ScallopConf}
 class Conf(args: Seq[String]) extends ScallopConf(args) {
   printedName = "easy-stage-dataset"
   version(s"$printedName v${Version()}")
+  private val padding = Array.fill(printedName.length)(' ').mkString("")
   banner(s"""
            |Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x Repository.
            |
@@ -17,7 +18,7 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
            | ____________ -b <EASY-bag> -s <staged-digital-object-set>
            |
            |Options:
-           |""".stripMargin.replaceAll("_+",printedName.replaceAll("."," ")))
+           |""".stripMargin.replaceAll("_+",padding))
 
   implicit val dateTimeConv: ValueConverter[DateTime] = singleArgConverter[DateTime](conv = DateTime.parse)
   val mayNotExist = singleArgConverter[File](conv = new File(_))

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -2,26 +2,37 @@ package nl.knaw.dans.easy.stage
 
 import java.io.File
 
+import nl.knaw.dans.easy.stage.EasyStageDataset._
 import org.joda.time.DateTime
 import org.rogach.scallop.{singleArgConverter, ValueConverter, ScallopConf}
+import org.slf4j.LoggerFactory
 
 class Conf(args: Seq[String]) extends ScallopConf(args) {
+  val log = LoggerFactory.getLogger(getClass)
+
   printedName = "easy-stage-dataset"
   version(s"$printedName v${Version()}")
-  private val padding = Array.fill(printedName.length)(' ').mkString("")
+  private val padding = printedName.map(_ => " ").mkString("")
   banner(s"""
            |Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x Repository.
            |
            |Usage:
            |
            | $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] \\
-           | ____________ -b <EASY-bag> -s <staged-digital-object-set>
+           | ____________    <EASY-bag> <staged-digital-object-set>
            |
            |Options:
            |""".stripMargin.replaceAll("_+",padding))
 
   implicit val dateTimeConv: ValueConverter[DateTime] = singleArgConverter[DateTime](conv = DateTime.parse)
   val mayNotExist = singleArgConverter[File](conv = new File(_))
+  val shouldExist = singleArgConverter[File](conv = {f =>
+    if (!new File(f).isDirectory) {
+      log.error(s"$f is not an existing directory")
+      throw new IllegalArgumentException()
+    }
+    new File(f)
+  })
 
   val submissionTimestamp = opt[DateTime](
     name = "submission-timestamp", short = 't',
@@ -39,12 +50,12 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
     name = "doi-is-other-access-doi", short = 'o',
     descr = """Stage the provided DOI as an "other access DOI"""",
     default = Some(false))
-  val bag = opt[File](
-    name = "EASY-bag", short = 'b',
+  val bag = trailArg[File](
+    name = "EASY-bag",
     descr = "Bag with extra metadata for EASY to be staged for ingest into Fedora",
-    required = true)
-  val sdoSet = opt[File](
-    name = "staged-digital-object-set", short = 's',
+    required = true)(shouldExist)
+  val sdoSet = trailArg[File](
+    name = "staged-digital-object-set",
     descr = "The resulting Staged Digital Object directory (will be created if it does not exist)",
     required = true)(mayNotExist)
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -7,7 +7,6 @@ import org.rogach.scallop.{singleArgConverter, ValueConverter, ScallopConf}
 
 class Conf(args: Seq[String]) extends ScallopConf(args) {
   printedName = "easy-stage-dataset"
-  val indent_____ = printedName.replaceAll(".", " ")
   version(s"$printedName v${Version()}")
   banner(s"""
            |Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x Repository.
@@ -15,12 +14,13 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
            |Usage:
            |
            | $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] \\
-           | $indent_____    <EASY-bag> <staged-digital-object-set>
+           | ____________ -b <EASY-bag> -s <staged-digital-object-set>
            |
            |Options:
-           |""".stripMargin)
+           |""".stripMargin.replaceAll("_+",printedName.replaceAll("."," ")))
 
-  implicit val conv: ValueConverter[DateTime] = singleArgConverter[DateTime](conv = DateTime.parse)
+  implicit val dateTimeConv: ValueConverter[DateTime] = singleArgConverter[DateTime](conv = DateTime.parse)
+  val mayNotExist = singleArgConverter[File](conv = new File(_))
 
   val submissionTimestamp = opt[DateTime](
     name = "submission-timestamp", short = 't',
@@ -38,12 +38,12 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
     name = "doi-is-other-access-doi", short = 'o',
     descr = """Stage the provided DOI as an "other access DOI"""",
     default = Some(false))
-  val bag = trailArg[File](
-    name = "EASY-bag",
+  val bag = opt[File](
+    name = "EASY-bag", short = 'b',
     descr = "Bag with extra metadata for EASY to be staged for ingest into Fedora",
     required = true)
-  val sdoSet = trailArg[String](
-    name = "staged-digital-object-set",
+  val sdoSet = opt[File](
+    name = "staged-digital-object-set", short = 's',
     descr = "The resulting Staged Digital Object directory (will be created if it does not exist)",
-    required = true)
+    required = true)(mayNotExist)
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -12,17 +12,17 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
 
   printedName = "easy-stage-dataset"
   version(s"$printedName v${Version()}")
-  private val padding = printedName.map(_ => " ").mkString("")
+  private val _________ = printedName.map(_ => " ").mkString("")
   banner(s"""
            |Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x Repository.
            |
            |Usage:
            |
            | $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] \\
-           | ____________    <EASY-bag> <staged-digital-object-set>
+           | ${_________}    <EASY-bag> <staged-digital-object-set>
            |
            |Options:
-           |""".stripMargin.replaceAll("_+",padding))
+           |""".stripMargin)
 
   implicit val dateTimeConv: ValueConverter[DateTime] = singleArgConverter[DateTime](conv = DateTime.parse)
   val mayNotExist = singleArgConverter[File](conv = new File(_))

--- a/src/main/scala/nl/knaw/dans/easy/stage/DatasetConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/DatasetConf.scala
@@ -2,12 +2,11 @@ package nl.knaw.dans.easy.stage
 
 import java.io.File
 
-import nl.knaw.dans.easy.stage.EasyStageDataset._
 import org.joda.time.DateTime
 import org.rogach.scallop.{singleArgConverter, ValueConverter, ScallopConf}
 import org.slf4j.LoggerFactory
 
-class Conf(args: Seq[String]) extends ScallopConf(args) {
+class DatasetConf(args: Seq[String]) extends ScallopConf(args) {
   val log = LoggerFactory.getLogger(getClass)
 
   printedName = "easy-stage-dataset"

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -24,7 +24,7 @@ object EasyStageDataset {
       submissionTimestamp = conf.submissionTimestamp().toString,
       bagStorageLocation = props.getString("storage-base-url"),
       bagitDir = conf.bag(),
-      sdoSetDir = new File(conf.sdoSet()),
+      sdoSetDir = conf.sdoSet(),
       URN = conf.urn(),
       DOI = conf.doi(),
       otherAccessDOI = conf.otherAccessDOI(),

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -17,7 +17,7 @@ object EasyStageDataset {
 
   def main(args: Array[String]) {
     val props = new PropertiesConfiguration(new File(System.getProperty("app.home"), "cfg/application.properties"))
-    val conf = new Conf(args)
+    val conf = new DatasetConf(args)
 
     implicit val s = Settings(
       ownerId = props.getString("owner"),

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageFileItem.scala
@@ -1,0 +1,31 @@
+package nl.knaw.dans.easy.stage
+
+import java.io.File
+
+import nl.knaw.dans.easy.stage.Constants._
+import nl.knaw.dans.easy.stage.EasyStageDataset._
+import nl.knaw.dans.easy.stage.Util._
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.slf4j.LoggerFactory
+
+import scala.util.{Try, Failure, Success}
+
+object EasyStageFileItem {
+  val log = LoggerFactory.getLogger(getClass)
+
+  def main(args: Array[String]) {
+    val props = new PropertiesConfiguration(new File(System.getProperty("app.home"), "cfg/application.properties"))
+    val conf = new FileItemConf(args)
+    println("hello world")
+    implicit val s = new FilItemSettings()
+    run match {
+      case Success(_) => log.info("Staging SUCCESS")
+      case Failure(t) => log.error("Staging FAIL", t)
+    }
+  }
+
+  def run(implicit s: FilItemSettings): Try[Unit] = {
+    log.debug(s"settings = $s")
+    ???
+  }
+}

--- a/src/main/scala/nl/knaw/dans/easy/stage/FilItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/FilItemSettings.scala
@@ -1,0 +1,5 @@
+package nl.knaw.dans.easy.stage
+
+class FilItemSettings() {
+
+}

--- a/src/main/scala/nl/knaw/dans/easy/stage/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/FileItemConf.scala
@@ -1,0 +1,42 @@
+package nl.knaw.dans.easy.stage
+
+import java.io.File
+
+import org.rogach.scallop._
+import org.slf4j.LoggerFactory
+
+class FileItemConf(args: Array[String]) extends ScallopConf {
+  val log = LoggerFactory.getLogger(getClass)
+
+  printedName = "easy-stage-file-item"
+  version(s"$printedName v${Version()}")
+  banner(s"""
+            |Stage a file item in EASY-BagIt format for ingest into a datasaet in an EASY Fedora Commons 3.x Repository.
+            |
+            |Usage:
+            |
+            | $printedName <options>... <EASY-bag> <staged-digital-object-set>
+            | or
+            | $printedName <EASY-bag> <staged-digital-object-set> < <csv-file>
+            |
+            |Options:
+            |""".stripMargin)
+
+  val mayNotExist = singleArgConverter[File](conv = new File(_))
+  val shouldExist = singleArgConverter[File](conv = {f =>
+    if (!new File(f).isDirectory) {
+      log.error(s"$f is not an existing directory")
+      throw new IllegalArgumentException()
+    }
+    new File(f)
+  })
+
+  val bag = trailArg[File](
+    name = "EASY-bag",
+    descr = "Bag with extra metadata for EASY to be staged for ingest into Fedora",
+    required = true)(shouldExist)
+  val sdoSet = trailArg[File](
+    name = "staged-digital-object-set",
+    descr = "An existing Staged Digital Object directory",
+    required = true)(shouldExist)
+}

--- a/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
 
 class ConfSpec extends FlatSpec with Matchers {
 
-  val commandLineArgs = "-t 2015 -u urn -d doi -b . -s -".split(" ")
+  val commandLineArgs = "-t 2015 -u urn -d doi . -".split(" ")
   private val conf = new Conf(commandLineArgs)
   val helpInfo = {
     val mockedStdOut = new ByteArrayOutputStream()

--- a/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
@@ -11,11 +11,12 @@ import scala.collection.JavaConverters._
 
 class ConfSpec extends FlatSpec with Matchers {
 
-  clearProperty("app.home")
+  val commandLineArgs = "-t 2015 -u urn -d doi -b . -s -".split(" ")
+  private val conf = new Conf(commandLineArgs)
   val helpInfo = {
     val mockedStdOut = new ByteArrayOutputStream()
     Console.withOut(mockedStdOut) {
-      new Conf(Seq("-t", "2015", "-u", "urn",  "-d", "doi", ".", ".")).printHelp()
+      conf.printHelp()
     }
     mockedStdOut.toString
   }
@@ -37,7 +38,7 @@ class ConfSpec extends FlatSpec with Matchers {
   }
 
   "distributed default properties" should "be valid options" in {
-    val optKeys = new Conf(Seq("-t2015", "-u urn",  "-d doi", ".", ".")).builder.opts.map(opt => opt.name).toArray
+    val optKeys = conf.builder.opts.map(opt => opt.name).toArray
     val propKeys = new PropertiesConfiguration("src/main/assembly/dist/cfg/application.properties")
       .getKeys.asScala.withFilter(key => key.startsWith("default.") )
 

--- a/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
 class ConfSpec extends FlatSpec with Matchers {
 
   val commandLineArgs = "-t 2015 -u urn -d doi . -".split(" ")
-  private val conf = new Conf(commandLineArgs)
+  private val conf = new DatasetConf(commandLineArgs)
   val helpInfo = {
     val mockedStdOut = new ByteArrayOutputStream()
     Console.withOut(mockedStdOut) {


### PR DESCRIPTION
The vague 'can not parse trailArg' becomes:

```
[easy-stage-dataset] Error: Bad arguments for option 'EASY-bag': 'xxx' - file 'xxx' doesn't exist
```

Still any string is accepted by Conf for staged-digital-object-set
