### PR TITLE
Easy 964

### DIFF
--- a/src/test/resources/dataset-bags/additional-license-by-text/metadata/dataset.xml
+++ b/src/test/resources/dataset-bags/additional-license-by-text/metadata/dataset.xml
@@ -3,8 +3,7 @@
          xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns:dcterms="http://purl.org/dc/terms/"
          xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2015/12/ddm.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ddm:profile>
         <dc:title>Dataset with files and an additional license specified by an embedded template</dc:title>
         <dc:description>A dataset with some files but no additional license</dc:description>

--- a/src/test/resources/dataset-bags/additional-license-by-text/tagmanifest-md5.txt
+++ b/src/test/resources/dataset-bags/additional-license-by-text/tagmanifest-md5.txt
@@ -1,5 +1,5 @@
 d4b9b6997ecfdc06739fd33cb7282b39  bag-info.txt
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
 f7d50cfdd217c3018d9752532c740f3b  manifest-md5.txt
-2a6fce6f7c9dc6db0bf452df45497414  metadata/dataset.xml
+d22cef2dab5215b082d0c8fd4ed3a1d0  metadata/dataset.xml
 b3e17a9949eb5a76d457803264986cb0  metadata/files.xml

--- a/src/test/resources/dataset-bags/additional-license-by-url/metadata/dataset.xml
+++ b/src/test/resources/dataset-bags/additional-license-by-url/metadata/dataset.xml
@@ -3,8 +3,7 @@
          xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns:dcterms="http://purl.org/dc/terms/"
          xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2015/12/ddm.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ddm:profile>
         <dc:title>Dataset with files and an additional license specified by a URI</dc:title>
         <dc:description>A dataset with some files but no additional license</dc:description>

--- a/src/test/resources/dataset-bags/additional-license-by-url/tagmanifest-md5.txt
+++ b/src/test/resources/dataset-bags/additional-license-by-url/tagmanifest-md5.txt
@@ -1,5 +1,5 @@
 a638d07544bb2b5531d4278e147f8d63  bag-info.txt
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
 f7d50cfdd217c3018d9752532c740f3b  manifest-md5.txt
-543a8e4a8fb47397728e5a5bcac21db0  metadata/dataset.xml
+80e93cc3259e4c8edab1e4439397f4ff  metadata/dataset.xml
 b3e17a9949eb5a76d457803264986cb0  metadata/files.xml

--- a/src/test/resources/dataset-bags/minimal/metadata/dataset.xml
+++ b/src/test/resources/dataset-bags/minimal/metadata/dataset.xml
@@ -2,8 +2,7 @@
 <ddm:DDM xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
          xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2015/12/ddm.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ddm:profile>
         <dc:title>Minimal dataset</dc:title>
         <dc:description>A dataset with no files and only minimal metadata</dc:description>

--- a/src/test/resources/dataset-bags/minimal/tagmanifest-md5.txt
+++ b/src/test/resources/dataset-bags/minimal/tagmanifest-md5.txt
@@ -1,4 +1,4 @@
 942ba7828f6ce720570e57e985e7ac5c  bag-info.txt
 68b329da9893e34099c7d8ad5cb9c940  manifest-md5.txt
-1e84884c263942ca49c5d330a830f055  metadata/dataset.xml
+c568da9b91bdba8059316c423fad0e5e  metadata/dataset.xml
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt

--- a/src/test/resources/dataset-bags/no-additional-license/metadata/dataset.xml
+++ b/src/test/resources/dataset-bags/no-additional-license/metadata/dataset.xml
@@ -3,8 +3,7 @@
          xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns:dcterms="http://purl.org/dc/terms/"
          xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2015/12/ddm.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <ddm:profile>
         <dc:title>Dataset with files but no additional license</dc:title>
         <dc:description>A dataset with some files but no additional license</dc:description>

--- a/src/test/resources/dataset-bags/no-additional-license/tagmanifest-md5.txt
+++ b/src/test/resources/dataset-bags/no-additional-license/tagmanifest-md5.txt
@@ -1,5 +1,5 @@
 b8e72fb2cd5ca12492386d805de1477e  bag-info.txt
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
 f7d50cfdd217c3018d9752532c740f3b  manifest-md5.txt
-38931ca2fb24381f9a7108bee6a8f57e  metadata/dataset.xml
+91af29d5196dca4275bd7b881d989f5f  metadata/dataset.xml
 b3e17a9949eb5a76d457803264986cb0  metadata/files.xml


### PR DESCRIPTION
updated test bags, because schema location was not needed in ddm anymore
