### PR TITLE
work in progress

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -1,14 +1,28 @@
+/**
+ * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
-import java.sql.{PreparedStatement, DriverManager}
+import java.sql.{DriverManager, PreparedStatement}
 
-import nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem._
-import nl.knaw.dans.easy.stage.lib.Props
 import nl.knaw.dans.easy.stage.lib.Props.props
 import org.slf4j.LoggerFactory
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 object EasyFilesAndFolders {
   val log = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -45,23 +45,25 @@ object EasyFilesAndFolders {
     }
   }
 
-  def getExistingParent(pathInDataset: String, datasetId: String): Try[Option[String]] = Try {
+  def getExistingAncestor(pathInDataset: String, datasetId: String): Try[Option[String]] = Try {
     val query: PreparedStatement = conn.prepareStatement("SELECT count(pid) FROM easy_folders WHERE path = ?")
-    val subPaths = pathInDataset
-      .split("/")
-      .scanLeft("")((acc, next) => acc + next + "/")
-      .reverse
-      .map(_.replaceAll("/$", ""))
-      .filter(!_.isEmpty)
-    val parentPath = subPaths.find(path => {
+    try {
+      val ancestors = pathInDataset
+        .split("/")
+        .scanLeft("")((acc, next) => acc + next + "/")
+        .reverse
+        .map(_.replaceAll("/$", ""))
+        .filter(!_.isEmpty)
+      ancestors.find(path => {
         query.setString(1, path)
         val resultSet = query.executeQuery()
-        // TODO don't forget to close the query?
-        if(!resultSet.next()) throw new RuntimeException("Count query returned no rows (?) A count query should ALWAYS return one row")
+        if (!resultSet.next()) throw new RuntimeException("Count query returned no rows (?) A count query should ALWAYS return one row")
         resultSet.getString("count") == "1"
       })
-    query.close()
-    parentPath
+    }
+    finally {
+      query.close()
+    }
   }
 
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -33,12 +33,13 @@ object EasyFilesAndFolders {
 
   def getExistingParent(pathInDataset: String, datasetId: String): Try[Option[String]] = Try {
     val query: PreparedStatement = conn.prepareStatement("SELECT count(pid) FROM easy_folders WHERE path = ?")
-    val parentPath = pathInDataset
+    val subPaths = pathInDataset
       .split("/")
       .scanLeft("")((acc, next) => acc + next + "/")
       .reverse
-      .map(_.replaceAll("/$",""))
-      .find(path => {
+      .map(_.replaceAll("/$", ""))
+      .filter(!_.isEmpty)
+    val parentPath = subPaths.find(path => {
         query.setString(1, path)
         val resultSet = query.executeQuery()
         // TODO don't forget to close the query?

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -1,18 +1,3 @@
-/**
- * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
@@ -32,7 +17,7 @@ object EasyFilesAndFolders {
 
   def getPathId(path: File, datasetSid: String): Try[Option[String]] = Try {
     val query: PreparedStatement = conn.prepareStatement("SELECT pid FROM easy_folders WHERE dataset_sid = ? and path = ?")
-    query.setString(2, path.toString +"/")
+    query.setString(2, path.toString)
     query.setString(1, datasetSid)
     log.debug(s"$query")
     query.closeOnCompletion()
@@ -52,12 +37,14 @@ object EasyFilesAndFolders {
       .split("/")
       .scanLeft("")((acc, next) => acc + next + "/")
       .reverse
+      .map(_.replaceAll("/$",""))
       .find(path => {
-          query.setString(1, path)
-          val resultSet = query.executeQuery()
-          if(!resultSet.next()) throw new RuntimeException("Count query returned no rows (?) A count query should ALWAYS return one row")
-          resultSet.getString("count") == "1"
-        })
+        query.setString(1, path)
+        val resultSet = query.executeQuery()
+        // TODO don't forget to close the query?
+        if(!resultSet.next()) throw new RuntimeException("Count query returned no rows (?) A count query should ALWAYS return one row")
+        resultSet.getString("count") == "1"
+      })
     query.close()
     parentPath
   }

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -81,9 +81,10 @@ object EasyStageFileItem {
     if (parentPath.isEmpty) new File(path) // prevent a leading slash
     else new File(parentPath, path)
 
+  /** @return (existingParentId, existingParentPath, newItems) */
   def getPathElements()(implicit s: FileItemSettings): Try[(String, String, Seq[String])] = Try {
     // TODO: refactor this to remove the need for get and toString
-    EasyFilesAndFolders.getExistingParent(s.pathInDataset.get.toString, s.datasetId.get).get match {
+    EasyFilesAndFolders.getExistingAncestor(s.pathInDataset.get.toString, s.datasetId.get).get match {
       case Some(path) =>
         log.debug(s"Found parent path folder in repository: $path")
         val parentId = EasyFilesAndFolders.getPathId(new File(path), s.datasetId.get).get.get

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -72,10 +72,14 @@ object EasyStageFileItem {
       (parentId, parentPath, newElements)  <- getPathElements()
       items            <- Try { getItemsToStage(newElements, datasetSdoSetDir, parentId) }
       _                = log.debug(s"Items to stage: $items")
-      _                = items.init.foreach { case (sdo, path, parentRelation) => createFolderSdo(sdo, new File(new File(parentPath), path).toString, parentRelation) }
-      _                = items.last match {case (sdo, path, parentRelation) => createFileSdo(sdo, new File(new File(parentPath), path).toString, parentRelation) }
+      _                = items.init.foreach { case (sdo, path, parentRelation) => createFolderSdo(sdo, fullPath(parentPath, path).toString, parentRelation) }
+      _                = items.last match {case (sdo, path, parentRelation) => createFileSdo(sdo, fullPath(parentPath, path).toString, parentRelation) }
     } yield ()
   }
+
+  def fullPath(parentPath: String, path: String): File =
+    if (parentPath.isEmpty) new File(path) // prevent a leading slash
+    else new File(parentPath, path)
 
   def getPathElements()(implicit s: FileItemSettings): Try[(String, String, Seq[String])] = Try {
     // TODO: refactor this to remove the need for get and toString

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -24,7 +24,6 @@ import nl.knaw.dans.easy.stage.lib.FOXML.{getDirFOXML, getFileFOXML}
 import nl.knaw.dans.easy.stage.lib.Util._
 import nl.knaw.dans.easy.stage.lib._
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Success, Try}
@@ -96,21 +95,21 @@ object EasyStageFileItem {
     getPaths(pathElements)
     .foldLeft(Seq[(File, String, (String, String))]())((items, path) => {
       items match {
-        case s@Seq() => s :+ (new File(datasetSdoSet, toSdoName(path)), path, ("object" -> existingFolderId))
+        case s@Seq() => s :+ (new File(datasetSdoSet, toSdoName(path)), path, "object" -> existingFolderId)
         case seq =>
           val parentFolderSdoName = seq.last match { case (sdo, _,  _) => sdo.getName}
-          seq :+ (new File(datasetSdoSet, toSdoName(path)), path, ("objectSDO" -> parentFolderSdoName))
+          seq :+ (new File(datasetSdoSet, toSdoName(path)), path, "objectSDO" -> parentFolderSdoName)
       }
     })
   }
 
   def getPaths(path: Seq[String]): Seq[String] =
     if(path.isEmpty) Seq()
-    else path.tail.scanLeft(path(0))((acc, next) => s"$acc/$next")
+    else path.tail.scanLeft(path.head)((acc, next) => s"$acc/$next")
 
 
   def createFileSdo(sdoDir: File, path: String, parent: (String,String))(implicit s: FileItemSettings): Try[Unit] = {
-    log.debug(s"Creating file SDO: ${path}")
+    log.debug(s"Creating file SDO: $path")
     sdoDir.mkdir()
     val location  = new URL(new URL(s.storageBaseUrl), s.pathInStorage.get.toString).toString
     for {

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -84,7 +84,7 @@ object EasyStageFileItem {
       case Some(path) =>
         log.debug(s"Found parent path folder in repository: $path")
         val parentId = EasyFilesAndFolders.getPathId(new File(path), s.datasetId.get).get.get
-        (parentId, path, s.pathInDataset.get.toString.replaceFirst(s"^$path", "").split("/").toSeq)
+        (parentId, path, s.pathInDataset.get.toString.replaceFirst(s"^$path/", "").split("/").toSeq)
       case None =>
         log.debug("No parent path found in repository, using dataset as parent")
         (s.datasetId.get, "", s.pathInDataset.get.toString.split("/").toSeq)


### PR DESCRIPTION
@janvanmansum 

Trying to add something to an existing folder now no longer complains about not finding it, but has the following incorrect content in cfg.json (and probably more problems):

```
"relations":[{
  "predicate":"http://dans.knaw.nl/ontologies/relations#isMemberOf",
  "objectSDO":"easy-dataset_3"
}
```

the third line should be something like

```
"object":"info:fedora/easy-folder:999"
```
