### PR TITLE
Simplications

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ deposits must conform to [BagIt] format.
 
 To prepare the deposit for inclusion in EASY `easy-stage-dataset` performs the following tasks:
 
-1. It generates the metadata required for an EASY dataset:
-   * Administrative Metadata
-   * EASY Metadata (descriptive metadata)
-   * ...
-2. It stages a digital object to represent the entire dataset for ingest in Fedora, using the metadata generated in 1.
-3. It stages a digital object for each file and folder in the dataset for ingest in Fedora.
+ 1. It generates the metadata required for an EASY dataset:
+    * Administrative Metadata
+    * EASY Metadata (descriptive metadata)
+    * ...
+ 2. It stages a digital object to represent the entire dataset for ingest in Fedora, using the metadata generated in 1.
+ 3. It stages a digital object for each file and folder in the dataset for ingest in Fedora.
 
 The results of steps 1-3 can be ingested into the EASY Fedora Commons Repository.
 The command `easy-stage-file-item` executes step 3 to stage a file for ingestion into an existing dataset.
@@ -55,19 +55,19 @@ ARGUMENTS for easy-stage-dataset
 ARGUMENTS for easy-stage-fileItem
 ---------------------------------
 
-    -i, --dataset-id  <arg>        id of the dataset in Fedora that should receive
-                                   the file to stage (requires file-path). If
-                                   omitted the trailing argument csf-file is
-                                   required
-        --format  <arg>            dcterms property format, the mime type of the
-                                   file
-    -p, --path-in-dataset  <arg>   the path that the file or folder should get in
-                                   the dataset
-        --path-in-storage  <arg>   Path of the file in storage, relative to the
-                                   storage-base-url, if omitted a folder is staged
-        --help                     Show help message
-        --version                  Show version of this program
-   
+    -i, --dataset-id  <arg>            id of the dataset in Fedora that should
+                                       receive the file to stage (requires
+                                       file-path). If omitted the trailing argument
+                                       csf-file is required
+    -d, --datastream-location  <arg>   http URL to redirect to
+        --format  <arg>                dcterms property format, the mime type of the
+                                       file
+    -p, --path-in-dataset  <arg>       the path that the file or folder should get
+                                       in the dataset
+    -s, --size  <arg>                  Size in bytes of the file data
+        --help                         Show help message
+        --version                      Show version of this program
+
     trailing arguments:
      csv-file (not required)                a comma separated file with one column
                                             for each option (additional columns are
@@ -75,7 +75,6 @@ ARGUMENTS for easy-stage-fileItem
      staged-digital-object-set (required)   The resulting Staged Digital Object
                                             directory (will be created if it does not
                                             exist)
-
 
 INSTALLATION AND CONFIGURATION
 ------------------------------

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,7 +1,7 @@
 owner={{ easy_stage_dataset_owner }}
-storage-base-url={{ easy_stage_dataset_storage_baseurl }}
 fcrepo.url={{ easy_stage_dataset_fcrepo_service_url }}
 fcrepo.user={{ easy_stage_dataset_fcrepo_user }}
 fcrepo.password={{ easy_stage_dataset_fcrepo_password }}
 db-connection-url={{ easy_stage_dataset_db_connection_url }}
+redirect-unset-url=http://unset.dans.knaw.nl
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -42,7 +42,6 @@ object EasyStageDataset {
     implicit val s = Settings(
       ownerId = props.getString("owner"),
       submissionTimestamp = conf.submissionTimestamp.apply().toString,
-      bagStorageLocation = props.getString("storage-base-url"),
       bagitDir = conf.bag(),
       sdoSetDir = conf.sdoSet(),
       URN = conf.urn(),
@@ -107,8 +106,8 @@ object EasyStageDataset {
       _ <- EasyStageFileItem.createFileSdo(sdoDir, relativePath, "objectSDO" -> parentSDO
       )(FileItemSettings(
         sdoSetDir = Some(s.sdoSetDir),
-        pathInStorage = Some(new File(relativePath)),
-        storageBaseUrl = s.bagStorageLocation,
+        dsLocation = None,
+        size = Some(file.length),
         ownerId = s.ownerId,
         pathInDataset = Some(new File(relativePath)),
         format = Some(mime)
@@ -122,7 +121,6 @@ object EasyStageDataset {
     for {
       sdoDir <- mkdirSafe(getSDODir(folder))
       _      <- EasyStageFileItem.createFolderSdo(sdoDir, relativePath, "objectSDO" -> parentSDO)(FileItemSettings(sdoSetDir = Some(s.sdoSetDir),
-                                        storageBaseUrl = s.bagStorageLocation,
                                         ownerId = s.ownerId,
                                         pathInDataset = Some(getDatasetRelativePath(folder).toFile)))
     } yield ()

--- a/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
@@ -23,7 +23,6 @@ import nl.knaw.dans.easy.stage.lib.Fedora
 
 case class Settings(ownerId: String,
                     submissionTimestamp: String,
-                    bagStorageLocation: String,
                     bagitDir: File,
                     sdoSetDir: File,
                     URN: String,

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
@@ -23,7 +23,7 @@ object EasyFileMetadata {
         <name>{s.pathInDataset.get.getName}</name>
         <path>{s.pathInDataset.get}</path>
         <mimeType>{s.format.getOrElse("application/octet-stream")}</mimeType>
-        <size>{s.pathInStorage.get.length}</size>
+        <size>{s.size.get}</size>
         <creatorRole>{s.creatorRole}</creatorRole>
         <visibleTo>{s.visibleTo}</visibleTo>
         <accessibleTo>{s.accessibleTo}</accessibleTo>

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -13,53 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
-import java.sql.{PreparedStatement, DriverManager}
+import java.sql.{DriverManager, PreparedStatement}
 
-import nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem._
-import nl.knaw.dans.easy.stage.lib.Props
 import nl.knaw.dans.easy.stage.lib.Props.props
 import org.slf4j.LoggerFactory
 
-import scala.util.{Failure, Success, Try}
+import scala.annotation.tailrec
+import scala.util.{Success, Try}
 
 object EasyFilesAndFolders {
   val log = LoggerFactory.getLogger(getClass)
 
   val conn = DriverManager.getConnection(props.getString("db-connection-url"))
 
-  def getPathId(path: File, datasetSid: String): Try[Option[String]] = Try {
-    val query: PreparedStatement = conn.prepareStatement("SELECT pid FROM easy_folders WHERE dataset_sid = ? and path = ?")
-    query.setString(2, path.toString +"/")
-    query.setString(1, datasetSid)
-    log.debug(s"$query")
-    query.closeOnCompletion()
-    val resultSet = query.executeQuery()
-    if (!resultSet.next())
-      None
-    else {
-      val result = resultSet.getString("pid")
-      log.debug(s"pathId = $result")
-      Some(result)
+  def getExistingAncestor(file: File, datasetId: String): Try[(String,String)] = {
+    val query: PreparedStatement = conn.prepareStatement("SELECT pid FROM easy_folders WHERE path = ?")
+
+    @tailrec
+    def get(file: File): (String,String) =
+      if(file==null)
+        (datasetId,"")
+      else {
+        query.setString(1, file.getParent)
+        val resultSet = query.executeQuery()
+        if (resultSet.next())
+          (file.getParent, resultSet.getString("pid"))
+        else get(file.getParentFile)
+      }
+
+    Try {
+      try {
+        get(file.getParentFile)
+      }
+      finally {
+        query.close()
+      }
     }
   }
-
-  def getExistingParent(pathInDataset: String, datasetId: String): Try[Option[String]] = Try {
-    val query: PreparedStatement = conn.prepareStatement("SELECT count(pid) FROM easy_folders WHERE path = ?")
-    val parentPath = pathInDataset
-      .split("/")
-      .scanLeft("")((acc, next) => acc + next + "/")
-      .reverse
-      .find(path => {
-          query.setString(1, path)
-          val resultSet = query.executeQuery()
-          if(!resultSet.next()) throw new RuntimeException("Count query returned no rows (?) A count query should ALWAYS return one row")
-          resultSet.getString("count") == "1"
-        })
-    query.close()
-    parentPath
-  }
-
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -24,7 +24,6 @@ import nl.knaw.dans.easy.stage.lib.FOXML.{getDirFOXML, getFileFOXML}
 import nl.knaw.dans.easy.stage.lib.Util._
 import nl.knaw.dans.easy.stage.lib._
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Success, Try}
@@ -73,49 +72,48 @@ object EasyStageFileItem {
       (parentId, parentPath, newElements)  <- getPathElements()
       items            <- Try { getItemsToStage(newElements, datasetSdoSetDir, parentId) }
       _                = log.debug(s"Items to stage: $items")
-      _                = items.init.foreach { case (sdo, path, parentRelation) => createFolderSdo(sdo, new File(new File(parentPath), path).toString, parentRelation) }
-      _                = items.last match {case (sdo, path, parentRelation) => createFileSdo(sdo, new File(new File(parentPath), path).toString, parentRelation) }
+      _                = items.init.foreach { case (sdo, path, parentRelation) => createFolderSdo(sdo, fullPath(parentPath, path).toString, parentRelation) }
+      _                = items.last match {case (sdo, path, parentRelation) => createFileSdo(sdo, fullPath(parentPath, path).toString, parentRelation) }
     } yield ()
   }
 
-  def getPathElements()(implicit s: FileItemSettings): Try[(String, String, Seq[String])] = Try {
-    // TODO: refactor this to remove the need for get and toString
-    EasyFilesAndFolders.getExistingParent(s.pathInDataset.get.toString, s.datasetId.get).get match {
-      case Some(path) =>
-        log.debug(s"Found parent path folder in repository: $path")
-        val parentId = EasyFilesAndFolders.getPathId(new File(path), s.datasetId.get).get.get
-        (parentId, path, s.pathInDataset.get.toString.replaceFirst(s"^$path", "").split("/").toSeq)
-      case None =>
-        log.debug("No parent path found in repository, using dataset as parent")
-        (s.datasetId.get, "", s.pathInDataset.get.toString.split("/").toSeq)
-    }
+  def fullPath(parentPath: String, path: String): File =
+    if (parentPath.isEmpty) new File(path) // prevent a leading slash
+    else new File(parentPath, path)
 
+  def getPathElements()(implicit s: FileItemSettings): Try[(String, String, Seq[String])] = {
+    val file = s.pathInDataset.get
+    EasyFilesAndFolders.getExistingAncestor(file, s.datasetId.get)
+      .map { case (parentPath, parentId) =>
+        log.debug(s"Parent in repository: $parentId $parentPath")
+        val newItems = file.toString.replaceFirst(s"^$parentPath/", "").split("/")
+        (parentId, parentPath, newItems.toSeq)
+      }
   }
 
   def getItemsToStage(pathElements: Seq[String], datasetSdoSet: File, existingFolderId: String): Seq[(File, String, (String, String))] = {
     getPaths(pathElements)
     .foldLeft(Seq[(File, String, (String, String))]())((items, path) => {
       items match {
-        case s@Seq() => s :+ (new File(datasetSdoSet, toSdoName(path)), path, ("object" -> existingFolderId))
+        case s@Seq() => s :+ (new File(datasetSdoSet, toSdoName(path)), path, "object" -> existingFolderId)
         case seq =>
           val parentFolderSdoName = seq.last match { case (sdo, _,  _) => sdo.getName}
-          seq :+ (new File(datasetSdoSet, toSdoName(path)), path, ("objectSDO" -> parentFolderSdoName))
+          seq :+ (new File(datasetSdoSet, toSdoName(path)), path, "objectSDO" -> parentFolderSdoName)
       }
     })
   }
 
   def getPaths(path: Seq[String]): Seq[String] =
     if(path.isEmpty) Seq()
-    else path.tail.scanLeft(path(0))((acc, next) => s"$acc/$next")
+    else path.tail.scanLeft(path.head)((acc, next) => s"$acc/$next")
 
 
   def createFileSdo(sdoDir: File, path: String, parent: (String,String))(implicit s: FileItemSettings): Try[Unit] = {
-    log.debug(s"Creating file SDO: ${path}")
+    log.debug(s"Creating file SDO: $path")
     sdoDir.mkdir()
-    val location  = new URL(new URL(s.storageBaseUrl), s.pathInStorage.get.toString).toString
     for {
       mime <- Try{s.format.get}
-      _ <- writeJsonCfg(sdoDir, JSON.createFileCfg(location, mime, parent, s.subordinate))
+      _ <- writeJsonCfg(sdoDir, JSON.createFileCfg(s.dsLocation.getOrElse(s.unsetUrl), mime, parent, s.subordinate))
       _ <- writeFoxml(sdoDir, getFileFOXML(s.pathInDataset.get.getName, s.ownerId, mime))
       _ <- writeFileMetadata(sdoDir, EasyFileMetadata(s).toString())
     } yield ()

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
+import java.net.URL
 
 import nl.knaw.dans.easy.stage.lib.Version
 import org.joda.time.DateTime
@@ -51,16 +52,19 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
   val format = opt[String](
     name = "format", noshort = true,
     descr = "dcterms property format, the mime type of the file")
-  val pathInStorage = opt[File](
-    name = "path-in-storage",
-    descr = "Path of the file in storage, relative to the storage-base-url, if omitted a folder is staged")(mayNotExist)
+  val dsLocation = opt[URL](
+    name = "datastream-location",
+    descr = "http URL to redirect to")
+  val size = opt[Long](
+    name = "size",
+    descr = "Size in bytes of the file data")
   val datasetId = opt[String](
     name = "dataset-id", short = 'i',
     descr = "id of the dataset in Fedora that should receive the file to stage (requires file-path). " +
      "If omitted the trailing argument csf-file is required")
   codependent(datasetId,pathInDataset)
-  codependent(pathInStorage,format)
-  dependsOnAll(pathInStorage, List(datasetId))
+  codependent(dsLocation,format)
+  dependsOnAll(dsLocation, List(datasetId))
 
   val csvFile = trailArg[File](
     name = "csv-file",

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
@@ -16,14 +16,16 @@
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
+import java.net.URL
 
 import nl.knaw.dans.easy.stage.lib.Props._
 
 case class FileItemSettings(sdoSetDir: Option[File],
                             datasetId: Option[String] = None,
-                            pathInStorage: Option[File] = None,
+                            dsLocation: Option[URL] = None,
+                            unsetUrl: URL = new URL(props.getString("redirect-unset-url")),
+                            size: Option[Long] = None,
                             ownerId: String = props.getString("owner"),
-                            storageBaseUrl: String = props.getString("storage-base-url"),
                             pathInDataset: Option[File],
                             format: Option[String] = None,
 
@@ -40,7 +42,8 @@ object FileItemSettings {
   def apply(conf: FileItemConf): FileItemSettings =
     new FileItemSettings(
       sdoSetDir = conf.sdoSetDir.get,
-      pathInStorage = conf.pathInStorage.get,
+      dsLocation = conf.dsLocation.get,
+      size = conf.size.get,
       datasetId = conf.datasetId.get,
       pathInDataset = conf.pathInDataset.get,
       format = conf.format.get,

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.stage.lib
 
+import java.net.URL
+
 import nl.knaw.dans.easy.stage.Settings
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
@@ -25,7 +27,7 @@ object JSON {
   val HAS_MODEL = "info:fedora/fedora-system:def/model#hasModel"
   val IS_MEMBER_OF = "http://dans.knaw.nl/ontologies/relations#isMemberOf"
   val IS_SUBORDINATE_TO = "http://dans.knaw.nl/ontologies/relations#isSubordinateTo"
-  val DATASET_ARCHIVAL_STORAGE_LOCATION = "http://dans.knaw.nl/ontologies/relations#datasetArchivalStorageLocation"
+  val STORED_IN_DARKARCHIVE = "http://dans.knaw.nl/ontologies/relations#storedInDarkArchive"
 
   def createDatasetCfg(mimeType: Option[String], audiences: Seq[String])(implicit s: Settings): String = {
 
@@ -61,7 +63,7 @@ object JSON {
         ("predicate" -> HAS_MODEL) ~ ("object" -> "info:fedora/dans-model:recursive-item-v1"),
         ("predicate" -> HAS_MODEL) ~ ("object" -> "info:fedora/easy-model:EDM1DATASET"),
         ("predicate" -> HAS_MODEL) ~ ("object" -> "info:fedora/easy-model:oai-item1"),
-        ("predicate" -> DATASET_ARCHIVAL_STORAGE_LOCATION) ~ ("object" -> s.bagStorageLocation) ~ ("isLiteral" -> true)
+        ("predicate" -> STORED_IN_DARKARCHIVE) ~ ("object" -> "true") ~ ("isLiteral" -> true)
         ) ++ audiences.map(audience =>
           ("predicate" -> IS_MEMBER_OF) ~ ("object" -> s"info:fedora/${s.disciplines(audience)}"))
       ))
@@ -69,14 +71,14 @@ object JSON {
     pretty(render(sdoCfg(audiences)))
   }
 
-  def createFileCfg(fileLocation: String,
+  def createFileCfg(fileLocation: URL,
                     mimeType: String,
                     parent: (String,String),
                     subordinate: (String,String)
                    ): String = {
       val json = ("namespace" -> "easy-file") ~
         ("datastreams" -> List(
-          ("dsLocation" -> fileLocation) ~
+          ("dsLocation" -> fileLocation.toString) ~
             ("dsID" -> "EASY_FILE") ~
             ("controlGroup" -> "R") ~
             ("mimeType" -> mimeType)

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
@@ -30,7 +30,7 @@ class CsvSpec extends FlatSpec with Matchers {
       "FORMAT,DATASET-ID,xxx,STAGED-DIGITAL-OBJECT-SET"
         .stripMargin.getBytes)
     the[Exception] thrownBy CSV(in, conf.longOptionNames).get should
-      have message "Missing columns: PATH-IN-DATASET, PATH-IN-STORAGE"
+      have message "Missing columns: PATH-IN-DATASET, DATASTREAM-LOCATION, SIZE"
   }
 
   it should "fail with uppercase in any of the required headers" in {


### PR DESCRIPTION
- Simplified processing of (external) file locations:  
  - easy-stage-dataset now just puts a dummy URL in the dsLocation of EASY_FILE
  - easy-stage-file-item takes the whole dsLocation as a parameter
- Relation that indicates that the dataset is in the darkarchive is now a simple
  boolean. The assumption is that the dataset is stored in a directory named
  with its urn.
- Incorporated (and squashed) @jo-pol's changes at https://github.com/DANS-KNAW/easy-stage-dataset/pull/54. I will close that pull request.
