### PR TITLE
command line validation, error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ARGUMENTS for easy-stage-fileItem
                                        csf-file is required
     -d, --datastream-location  <arg>   http URL to redirect to
         --format  <arg>                dcterms property format, the mime type of the
-                                       file
+                                       file (default 'application/octet-stream')
     -p, --path-in-dataset  <arg>       the path that the file should get in the
                                        dataset, a staged digital object is created
                                        for the file and the ancestor folders that

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -17,10 +17,9 @@ package nl.knaw.dans.easy.stage
 
 import java.io.File
 
-import nl.knaw.dans.easy.stage.EasyStageDataset._
 import nl.knaw.dans.easy.stage.lib.Version
 import org.joda.time.DateTime
-import org.rogach.scallop.{singleArgConverter, ValueConverter, ScallopConf}
+import org.rogach.scallop.{ScallopConf, ValueConverter, singleArgConverter}
 import org.slf4j.LoggerFactory
 
 class Conf(args: Seq[String]) extends ScallopConf(args) {

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -105,11 +105,10 @@ object EasyStageDataset {
       mime <- readMimeType(getBagRelativePath(file).toString)
       _ <- EasyStageFileItem.createFileSdo(sdoDir, relativePath, "objectSDO" -> parentSDO
       )(FileItemSettings(
-        sdoSetDir = Some(s.sdoSetDir),
-        dsLocation = None,
-        size = Some(file.length),
+        sdoSetDir = s.sdoSetDir,
         ownerId = s.ownerId,
-        pathInDataset = Some(new File(relativePath)),
+        pathInDataset = new File(relativePath),
+        size = Some(file.length),
         format = Some(mime)
       ))
     } yield ()
@@ -120,9 +119,8 @@ object EasyStageDataset {
     val relativePath= getDatasetRelativePath(folder).toString
     for {
       sdoDir <- mkdirSafe(getSDODir(folder))
-      _      <- EasyStageFileItem.createFolderSdo(sdoDir, relativePath, "objectSDO" -> parentSDO)(FileItemSettings(sdoSetDir = Some(s.sdoSetDir),
-                                        ownerId = s.ownerId,
-                                        pathInDataset = Some(getDatasetRelativePath(folder).toFile)))
+      fis     = FileItemSettings(s.sdoSetDir, s.ownerId, getDatasetRelativePath(folder).toFile, None, None)
+      _      <- EasyStageFileItem.createFolderSdo(sdoDir, relativePath, "objectSDO" -> parentSDO)(fis)
     } yield ()
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
@@ -22,8 +22,8 @@ object EasyFileMetadata {
       <fimd:file-item-md xmlns:fimd="http://easy.dans.knaw.nl/easy/file-item-md/" version="0.1" >
         <name>{s.pathInDataset.get.getName}</name>
         <path>{s.pathInDataset.get}</path>
-        <mimeType>{s.format.getOrElse("application/octet-stream")}</mimeType>
-        <size>{s.size.getOrElse(0)}</size>
+        <mimeType>{s.format.get}</mimeType>
+        <size>{s.size.get}</size>
         <creatorRole>{s.creatorRole}</creatorRole>
         <visibleTo>{s.visibleTo}</visibleTo>
         <accessibleTo>{s.accessibleTo}</accessibleTo>

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -26,8 +26,6 @@ import scala.annotation.tailrec
 import scala.util.Try
 
 object EasyFilesAndFolders {
-  val log = LoggerFactory.getLogger(getClass)
-
   val conn = DriverManager.getConnection(props.getString("db-connection-url"))
 
   def getExistingAncestor(file: File, datasetId: String): Try[(String,String)] = {

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -23,7 +23,7 @@ import nl.knaw.dans.easy.stage.lib.Props.props
 import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
-import scala.util.{Success, Try}
+import scala.util.Try
 
 object EasyFilesAndFolders {
   val log = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyItemContainerMd.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyItemContainerMd.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.stage.fileitem
 
-import java.io.File
-
 object EasyItemContainerMd {
 
   def apply(path: String): String = {

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -46,7 +46,7 @@ object EasyStageFileItem {
     }.recover { case t: Throwable => log.error(s"Staging FAIL of $conf", t) }
   }
 
-  private def getSettingsRows(conf: FileItemConf): Try[Seq[FileItemSettings]] =
+  def getSettingsRows(conf: FileItemConf): Try[Seq[FileItemSettings]] =
     if (conf.datasetId.isDefined)
       Success(Seq(FileItemSettings(conf)))
     else if (conf.csvFile.isEmpty)
@@ -58,7 +58,10 @@ object EasyStageFileItem {
           warning.map(msg => log.warn(msg))
           val rows = csv.getRows
           if (rows.isEmpty) log.warn(s"Empty CSV file")
-          rows.map(options => FileItemSettings(options ++ trailArgs))
+          rows.map{options =>
+            log.info(options.mkString(" "))
+            FileItemSettings(options ++ trailArgs)
+          }
       }
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
-import java.net.URL
 import java.sql.SQLException
 
 import com.yourmediashelf.fedora.client.FedoraClientException
@@ -72,14 +71,14 @@ object EasyStageFileItem {
       (parentId, parentPath, newElements)  <- getPathElements()
       items            <- Try { getItemsToStage(newElements, datasetSdoSetDir, parentId) }
       _                = log.debug(s"Items to stage: $items")
-      _                = items.init.foreach { case (sdo, path, parentRelation) => createFolderSdo(sdo, fullPath(parentPath, path).toString, parentRelation) }
-      _                <- items.last match {case (sdo, path, parentRelation) => createFileSdo(sdo, fullPath(parentPath, path).toString, parentRelation) }
+      _                <- Try{items.init.foreach { case (sdo, path, parentRelation) => createFolderSdo(sdo, relPath(parentPath, path), parentRelation) }}
+      _                <- items.last match {case (sdo, path, parentRelation) => createFileSdo(sdo, relPath(parentPath, path), parentRelation) }
     } yield ()
   }
 
-  def fullPath(parentPath: String, path: String): File =
-    if (parentPath.isEmpty) new File(path) // prevent a leading slash
-    else new File(parentPath, path)
+  def relPath(parentPath: String, path: String): String =
+    if (parentPath.isEmpty) new File(path).toString // prevent a leading slash
+    else new File(parentPath, path).toString
 
   def getPathElements()(implicit s: FileItemSettings): Try[(String, String, Seq[String])] = {
     val file = s.pathInDataset.get
@@ -113,7 +112,7 @@ object EasyStageFileItem {
     sdoDir.mkdir()
     for {
       mime <- Try{s.format.get}
-      _ <- writeJsonCfg(sdoDir, JSON.createFileCfg(s.dsLocation.getOrElse(s.unsetUrl), mime, parent, s.subordinate))
+      _ <- writeJsonCfg(sdoDir, JSON.createFileCfg(s.datastreamLocation.getOrElse(s.unsetUrl), mime, parent, s.subordinate))
       _ <- writeFoxml(sdoDir, getFileFOXML(s.pathInDataset.get.getName, s.ownerId, mime))
       fmd <- EasyFileMetadata(s)
       _ <- writeFileMetadata(sdoDir, fmd)

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -19,7 +19,7 @@ import java.io.File
 import java.net.URL
 
 import nl.knaw.dans.easy.stage.lib.Version
-import org.rogach.scallop.{ScallopConf, TrailingArgsOption, ValueConverter, singleArgConverter}
+import org.rogach.scallop._
 import org.slf4j.LoggerFactory
 
 class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
@@ -66,8 +66,6 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
     name = "dataset-id", short = 'i',
     descr = "id of the dataset in Fedora that should receive the file to stage (requires file-path). " +
      "If omitted the trailing argument csf-file is required")
-  codependent(datasetId,pathInDataset,size,dsLocation)
-  dependsOnAll(format,List(datasetId))
 
   val csvFile = trailArg[File](
     name = "csv-file",
@@ -79,6 +77,10 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
     descr = "The resulting directory with Staged Digital Object directories per dataset" +
       " (will be created if it does not exist)",
     required = true)(mayNotExist)
+
+  dependsOnAll(format,List(datasetId,pathInDataset,size,dsLocation))
+  dependsOnAll(datasetId,List(pathInDataset,size,dsLocation))
+  conflicts(csvFile,List(datasetId,pathInDataset,size,dsLocation))
   requireOne(csvFile,datasetId)
 
   val longOptionNames = builder.opts.filter(!_.isInstanceOf[TrailingArgsOption]).map(_.name)

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -19,8 +19,7 @@ import java.io.File
 import java.net.URL
 
 import nl.knaw.dans.easy.stage.lib.Version
-import org.joda.time.DateTime
-import org.rogach.scallop.{TrailingArgsOption, ScallopConf, ValueConverter, singleArgConverter}
+import org.rogach.scallop.{ScallopConf, TrailingArgsOption, ValueConverter, singleArgConverter}
 import org.slf4j.LoggerFactory
 
 class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
@@ -38,8 +37,12 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
             |Options:
             |""".stripMargin)
 
-
-  implicit val dateTimeConv: ValueConverter[DateTime] = singleArgConverter[DateTime](conv = DateTime.parse)
+  val httpUrl: ValueConverter[URL] = singleArgConverter[URL](s => {
+    val result = new URL(s)
+    if(result.getProtocol == null || !result.getProtocol.startsWith("http"))
+      throw new IllegalArgumentException(s"$s should have protocol http")
+    result
+  })
   val mayNotExist = singleArgConverter[File](conv = new File(_))
   val shouldBeFile = singleArgConverter[File](conv = {f =>
     if (!new File(f).isFile) throw new IllegalArgumentException(s"$f is not an existing file")
@@ -51,11 +54,11 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
     descr = "the path that the file should get in the dataset, a staged digital object is created" +
       " for the file and the ancestor folders that don't yet exist in the dataset")(mayNotExist)
   val format = opt[String](
-    name = "format", noshort = true,
-    descr = "dcterms property format, the mime type of the file")
+    name = "format", noshort = true, // default applied when assigned to FileItemSettings
+    descr = "dcterms property format, the mime type of the file (default 'application/octet-stream')")
   val dsLocation = opt[URL](
     name = "datastream-location",
-    descr = "http URL to redirect to")
+    descr = "http URL to redirect to")(httpUrl)
   val size = opt[Long](
     name = "size",
     descr = "Size in bytes of the file data")
@@ -63,9 +66,8 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
     name = "dataset-id", short = 'i',
     descr = "id of the dataset in Fedora that should receive the file to stage (requires file-path). " +
      "If omitted the trailing argument csf-file is required")
-  codependent(datasetId,pathInDataset)
-  codependent(dsLocation,format)
-  dependsOnAll(dsLocation, List(datasetId))
+  codependent(datasetId,pathInDataset,size,dsLocation)
+  dependsOnAll(format,List(datasetId))
 
   val csvFile = trailArg[File](
     name = "csv-file",
@@ -77,8 +79,13 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
     descr = "The resulting directory with Staged Digital Object directories per dataset" +
       " (will be created if it does not exist)",
     required = true)(mayNotExist)
+  requireOne(csvFile,datasetId)
 
   val longOptionNames = builder.opts.filter(!_.isInstanceOf[TrailingArgsOption]).map(_.name)
 
   override def toString = builder.args.mkString(", ")
+}
+
+object FileItemConf {
+  val dummy = new FileItemConf("-ii -dhttp:// -pp -s0 --format f outdir".split(" "))
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
@@ -20,33 +20,51 @@ import java.net.URL
 
 import nl.knaw.dans.easy.stage.lib.Props._
 
-case class FileItemSettings(sdoSetDir: Option[File],
-                            datasetId: Option[String] = None,
-                            dsLocation: Option[URL] = None,
-                            unsetUrl: URL = new URL(props.getString("redirect-unset-url")),
-                            size: Option[Long] = None,
-                            ownerId: String = props.getString("owner"),
-                            pathInDataset: Option[File],
-                            format: Option[String] = None,
+case class FileItemSettings private (sdoSetDir: Option[File],
+                                     datasetId: Option[String],
+                                     datastreamLocation: Option[URL],
+                                     unsetUrl: URL = new URL(props.getString("redirect-unset-url")),
+                                     size: Option[Long],
+                                     ownerId: String = props.getString("owner"),
+                                     pathInDataset: Option[File],
+                                     format: Option[String] = None,
 
-                            // as in SDO/*/EASY_FILE_METADATA
-                            creatorRole: String = "DEPOSITOR",
-                            visibleTo: String = "ANONYMOUS",
-                            accessibleTo: String = "NONE",
+                                     // as in SDO/*/EASY_FILE_METADATA
+                                     creatorRole: String = "DEPOSITOR",
+                                     visibleTo: String = "ANONYMOUS",
+                                     accessibleTo: String = "NONE",
 
-                            subordinate: (String, String) = "objectSDO" -> "dataset"
-                           )
+                                     subordinate: (String, String))
 
 object FileItemSettings {
 
+  /** new file or folder for a new dataset */
+  def apply(sdoSetDir: File,
+            ownerId: String,
+            pathInDataset: File,
+            format: Option[String],
+            size: Option[Long]
+           ) =
+    new FileItemSettings(
+      sdoSetDir = Some(sdoSetDir),
+      datasetId = None,
+      datastreamLocation = None,
+      size = size,
+      ownerId = ownerId,
+      pathInDataset = Some(pathInDataset),
+      format = format,
+      subordinate = "objectSDO" -> "dataset"
+    )
+
+  /** new file or folder for an existing dataset */
   def apply(conf: FileItemConf): FileItemSettings =
     new FileItemSettings(
       sdoSetDir = conf.sdoSetDir.get,
-      dsLocation = conf.dsLocation.get,
+      datastreamLocation = conf.dsLocation.get,
       size = conf.size.get,
       datasetId = conf.datasetId.get,
       pathInDataset = conf.pathInDataset.get,
-      format = conf.format.get,
+      format = if (conf.format.isDefined) conf.format.get else Some("application/octet-stream"),
       subordinate = "object" -> s"info:fedora/${conf.datasetId()}"
     ) {
       override def toString = conf.toString

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
@@ -58,7 +58,7 @@ object FileItemSettings {
 
   /** new file or folder for an existing dataset */
   def apply(conf: FileItemConf): FileItemSettings =
-    new FileItemSettings(
+      new FileItemSettings(
       sdoSetDir = conf.sdoSetDir.get,
       datastreamLocation = conf.dsLocation.get,
       size = conf.size.get,

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Fedora.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Fedora.scala
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.easy.stage.lib
 
-import com.yourmediashelf.fedora.client.FedoraClient._
 import com.yourmediashelf.fedora.client.request.FedoraRequest
 import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Props.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Props.scala
@@ -17,9 +17,7 @@ package nl.knaw.dans.easy.stage.lib
 
 import java.io.File
 
-import nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem._
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.slf4j.LoggerFactory
 
 object Props {
   def apply(): PropertiesConfiguration = props

--- a/src/test/resources/example.csv
+++ b/src/test/resources/example.csv
@@ -4,7 +4,7 @@ Sample input for an integration test assuming a dataset submitted by an ordinary
 Beware for a plain comma in comment. After all it is a comma separated file.
 
 the next line should cause an error message in the log
-,easy-dataset:oops,1,oops
+,easy-dataset:oops,0,x,oops,http://dummy.dans.knaw.nl/ook/maar/wat.mpg
 
 the next line creates a new file item in a new folder item
 ,easy-dataset:1,1,video/mpeg,newRootFolder/file1.mpeg,http://some.dans.knaw.nl/location/a

--- a/src/test/resources/example.csv
+++ b/src/test/resources/example.csv
@@ -1,16 +1,20 @@
-comment,DATASET-ID,FILE-PATH,FILE,MD5,FORMAT,IDENTIFIER,TITLE,DESCRIPTION,CREATED
+comment,DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION
 
-All files should exist: otherwise FileItemCsvSpec will terminate all tests.
-The folder "original" requires the first dataset submitted by an ordinary user; not an archivist.
+Sample input for an integration test assuming a dataset submitted by an ordinary user (read: not an archivist)
 Beware for a plain comma in comment. After all it is a comma separated file.
 
-,easy-dataset:oops,oops
-,easy-dataset:1,newRootFolder
-,easy-dataset:1,original/newSub
-,easy-dataset:1,newRootFolder/newParentFolder
-,easy-dataset:1,missingParent/newSub
+the next line should cause an error message in the log
+,easy-dataset:oops,1,oops
 
-,easy-dataset:1,newRootFolder/newParentFolder/qs.hs,src/test/resources/example-bag/data/quicksort.hs,eb0c93c460fac5cca0fd789d17c52daa,text
-,easy-dataset:1,original/qs.hs,src/test/resources/example-bag/data/quicksort.hs,eb0c93c460fac5cca0fd789d17c52daa,text
-,easy-dataset:1,file.txt,src/test/resources/example-bag/data/path/to/file.txt,3d1b22d2ccb7606ada5267e5175d2601,text
+the next line creates a new file item in a new folder item
+,easy-dataset:1,1,video/mpeg,newRootFolder/file1.mpeg,http://some.dans.knaw.nl/location/a
+
+the next line creates a new file item in an existing folder item
+,easy-dataset:1,1,video/mpeg,original/file2.mpeg,http://some.dans.knaw.nl/location/b
+
+the next line creates a new file item in new folder items
+,easy-dataset:1,1,video/mpeg,newRootFolder/newParentFolder/file3.mpeg,http://some.dans.knaw.nl/location/c
+
+the next line creates a new file item in a new folder item
+,easy-dataset:1,1,video/mpeg,original/newSub/file.mpeg4,http://some.dans.knaw.nl/location/d
 

--- a/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/ConfSpec.scala
@@ -15,15 +15,10 @@
  */
 package nl.knaw.dans.easy.stage
 
-import java.io.{ByteArrayOutputStream, File}
-import java.lang.System.clearProperty
-
-import org.apache.commons.configuration.PropertiesConfiguration
-import org.rogach.scallop.ScallopConf
-import org.scalatest.{Matchers, FlatSpec}
+import java.io.File
 
 import nl.knaw.dans.easy.stage.CustomMatchers._
-import scala.collection.JavaConverters._
+import org.rogach.scallop.ScallopConf
 
 class ConfSpec extends AbstractConfSpec {
 

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -25,10 +25,10 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
 
   "getItemsToStage" should "return list of SDO with parent relations that are internally consistent" in {
     getItemsToStage(Seq("path", "to", "new", "file.txt"), file("dataset-sdo-set"), "easy-folder:123") shouldBe
-    Seq((file("dataset-sdo-set/path"), "path", ("object" -> "info:fedora/easy-folder:123")),
-      (file("dataset-sdo-set/path_to"), "path/to", ("objectSDO" -> "path")),
-      (file("dataset-sdo-set/path_to_new"), "path/to/new", ("objectSDO" -> "path_to")),
-      (file("dataset-sdo-set/path_to_new_file_txt"), "path/to/new/file.txt", ("objectSDO" -> "path_to_new")))
+    Seq((file("dataset-sdo-set/path"), "path", "object" -> "info:fedora/easy-folder:123"),
+      (file("dataset-sdo-set/path_to"), "path/to", "objectSDO" -> "path"),
+      (file("dataset-sdo-set/path_to_new"), "path/to/new", "objectSDO" -> "path_to"),
+      (file("dataset-sdo-set/path_to_new_file_txt"), "path/to/new/file.txt", "objectSDO" -> "path_to_new"))
   }
 
   it should "return an empty Seq when given one" in {
@@ -36,6 +36,6 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
   }
 
   it should "return only a file item if path contains one element" in {
-    getItemsToStage(Seq("file.txt"), file("dataset-sdo-set"), "easy-folder:123") shouldBe Seq((file("dataset-sdo-set/file_txt"), "file.txt", ("object" -> "info:fedora/easy-folder:123")))
+    getItemsToStage(Seq("file.txt"), file("dataset-sdo-set"), "easy-folder:123") shouldBe Seq((file("dataset-sdo-set/file_txt"), "file.txt", "object" -> "info:fedora/easy-folder:123"))
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -16,12 +16,12 @@
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
-import java.net.MalformedURLException
 
-import org.scalatest.{Matchers, FlatSpec}
-import EasyStageFileItem._
+import nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem._
+import org.scalatest.{FlatSpec, Matchers}
 
 class EasyStageFileItemSpec extends FlatSpec with Matchers {
+  System.setProperty("app.home", "src/main/assembly/dist")
   def file(p: String) = new File(p)
 
   "getItemsToStage" should "return list of SDO with parent relations that are internally consistent" in {
@@ -40,14 +40,12 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
     getItemsToStage(Seq("file.txt"), file("dataset-sdo-set"), "easy-folder:123") shouldBe Seq((file("dataset-sdo-set/file_txt"), "file.txt", "object" -> "info:fedora/easy-folder:123"))
   }
 
-  "getSettingsRows" should "fail with dummy conf" in {
-    (the[MalformedURLException] thrownBy getSettingsRows(FileItemConf.dummy).get).getMessage shouldBe null
+  "getSettingsRows" should "create a single row from dummy conf" in {
+    getSettingsRows(FileItemConf.dummy).get.size shouldBe 1
   }
 
-  ignore should "process example.csv" in {
-    // TODO fix MalformedURLException, the logged arguments applied on the command line are fine
-    val conf = new FileItemConf("src/test/resources/example.csv outdir".split(" "))
-    val rows = getSettingsRows(conf).get
-    rows.size shouldBe 5
+  it should "create multiple rows from example.csv" in {
+    val args = "src/test/resources/example.csv outdir".split(" ")
+    getSettingsRows(new FileItemConf(args)).get.size shouldBe 5
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
+import java.net.MalformedURLException
 
 import org.scalatest.{Matchers, FlatSpec}
 import EasyStageFileItem._
@@ -37,5 +38,16 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
 
   it should "return only a file item if path contains one element" in {
     getItemsToStage(Seq("file.txt"), file("dataset-sdo-set"), "easy-folder:123") shouldBe Seq((file("dataset-sdo-set/file_txt"), "file.txt", "object" -> "info:fedora/easy-folder:123"))
+  }
+
+  "getSettingsRows" should "fail with dummy conf" in {
+    (the[MalformedURLException] thrownBy getSettingsRows(FileItemConf.dummy).get).getMessage shouldBe null
+  }
+
+  ignore should "process example.csv" in {
+    // TODO fix MalformedURLException, the logged arguments applied on the command line are fine
+    val conf = new FileItemConf("src/test/resources/example.csv outdir".split(" "))
+    val rows = getSettingsRows(conf).get
+    rows.size shouldBe 5
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConfSpec.scala
@@ -21,8 +21,4 @@ import org.rogach.scallop.ScallopConf
 class FileItemConfSpec extends AbstractConfSpec {
 
   override def getConf: ScallopConf = FileItemConf.dummy
-
-  "constructor" should "accept example.csv" in {
-    new FileItemConf("src/test/resources/example.csv outdir".split(" "))
-  }
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConfSpec.scala
@@ -20,5 +20,9 @@ import org.rogach.scallop.ScallopConf
 
 class FileItemConfSpec extends AbstractConfSpec {
 
-  override def getConf: ScallopConf = new FileItemConf("-".split(" "))
+  override def getConf: ScallopConf = FileItemConf.dummy
+
+  "constructor" should "accept example.csv" in {
+    new FileItemConf("src/test/resources/example.csv outdir".split(" "))
+  }
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
@@ -17,13 +17,12 @@ package nl.knaw.dans.easy.stage.lib
 
 import java.io.{ByteArrayInputStream, FileInputStream}
 
-import nl.knaw.dans.easy.stage.fileitem.{FileItemSettings, FileItemConf}
+import nl.knaw.dans.easy.stage.fileitem.FileItemConf
 import org.scalatest.{FlatSpec, Matchers}
 
 class CsvSpec extends FlatSpec with Matchers {
 
-  private val commandLineArgs = "target/test/sdo-set".split(" ")
-  private val conf = new FileItemConf(commandLineArgs)
+  private val conf = FileItemConf.dummy
 
   "apply" should "fail with too few headers in the input" in {
     val in = new ByteArrayInputStream (
@@ -36,5 +35,11 @@ class CsvSpec extends FlatSpec with Matchers {
   it should "fail with uppercase in any of the required headers" in {
     val in = new ByteArrayInputStream ("".stripMargin.getBytes)
     (the[Exception] thrownBy CSV(in, Seq("ABc", "def")).get).getMessage should include ("not supported")
+  }
+
+  it should "accept example.csv" in {
+    val in = new FileInputStream ("src/test/resources/example.csv")
+    val (csv,_) = CSV(in, conf.longOptionNames).get
+    csv.getRows.size shouldBe 5
   }
 }


### PR DESCRIPTION
@DANS-KNAW/easy 
- either all options (only format is optional) or csv file
- default for mimetype/format moved from only EASY_FILE_METADATA
  to creation of FileItemSettings as it is also applied in fo.xml and cfg.json
- only http protocol
- reduced warings: imports, brackets
- changed for{... _ = ...foreach(..=>Try(..)}
  into for{... _ = Try{...foreach(..=>Try(..)}}
  to not loose failures
