### PR TITLE
EASY-984 UTF-8-encoded metadata misvormd bij stagen dataset voor Fedora ingest.

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/EMD.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/EMD.scala
@@ -38,7 +38,13 @@ object EMD {
       emd <- getEasyMetadata(ddm)
       _   = s.URN.foreach(urn => emd.getEmdIdentifier.add(wrapUrn(urn)))
       _   = s.DOI.foreach(doi => emd.getEmdIdentifier.add(wrapDoi(doi, s.otherAccessDOI)))
-      _   <- writeEMD(sdoDir, new EmdMarshaller(emd).getXmlString)
+          /*
+           * DO NOT USE getXmlString !! It will get the XML bytes and convert them to string using the
+           * platform's default Charset, which may not be what we expect.
+           *
+           * See https://drivenbydata.atlassian.net/browse/EASY-984
+           */
+      _   <- writeEMD(sdoDir, new String(new EmdMarshaller(emd).getXmlByteArray, "UTF-8"))
     } yield emd
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.stage.lib
 
 import java.io.File
 
+import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Try}
@@ -25,7 +26,15 @@ object Util {
   val log = LoggerFactory.getLogger(getClass)
 
   def writeToFile(f: File, s: String): Try[Unit] =
-    Try { scala.tools.nsc.io.File(f).writeAll(s) }
+    /*
+     * DO NOT USE THE SCALA File CLASS TO WRITE THE XML.
+     * It does not have a Charset parameter, so it will try to write in the
+     * platform's default Charset, resulting in question marks for characters that
+     * are not in that Charset.
+     *
+     * See: https://drivenbydata.atlassian.net/browse/EASY-984
+     */
+    Try { FileUtils.write(f, s, "UTF-8")}
 
   def writeJsonCfg(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "cfg.json"), content)


### PR DESCRIPTION
Fixed this by specifying UTF-8 hard-coded in two places.

@lindareijnhoudt @PaulBoon @rvanheest @ekoi @jo-pol please review.
