### PR TITLE
EASY-984 Charset problems with XML

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -70,7 +70,6 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
     name = "staged-digital-object-set",
     descr = "The resulting Staged Digital Object directory (will be created if it does not exist)",
     required = true)(mayNotExist)
-  codependent(urn,doi)
 }
 
 object Conf {

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -64,7 +64,7 @@ object EasyStageDataset {
       foxmlContent = getDatasetFOXML(s.ownerId, emdContent)
       mimeType <- AdditionalLicense.createOptionally(sdoDir)
       audiences <- readAudiences()
-      jsonCfgContent = JSON.createDatasetCfg(mimeType, audiences)
+      jsonCfgContent <- JSON.createDatasetCfg(mimeType, audiences)
       _ <- writeAMD(sdoDir, amdContent)
       _ <- writeFoxml(sdoDir, foxmlContent)
       _ <- writePrsql(sdoDir, PRSQL.create())

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/EMD.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/EMD.scala
@@ -38,7 +38,14 @@ object EMD {
       emd <- getEasyMetadata(ddm)
       _   = s.URN.foreach(urn => emd.getEmdIdentifier.add(wrapUrn(urn)))
       _   = s.DOI.foreach(doi => emd.getEmdIdentifier.add(wrapDoi(doi, s.otherAccessDOI)))
-      _   <- writeEMD(sdoDir, new EmdMarshaller(emd).getXmlString)
+          /*
+           * DO NOT USE getXmlString !! It will get the XML bytes and convert them to string using the
+           * platform's default Charset, which may not be what we expect.
+           *
+           * See https://drivenbydata.atlassian.net/browse/EASY-984
+           */
+      _   <- writeEMD(sdoDir, new String(new EmdMarshaller(emd).getXmlByteArray, "UTF-8"))
+
     } yield emd
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/FOXML.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/FOXML.scala
@@ -23,7 +23,7 @@ object FOXML {
 
   def getDatasetFOXML(ownerId: String, emd: EasyMetadata): String = {
     /*
-     * NOTE: DO NOT USER THE asXMLString method. It uses the platform's default charset, which can lead to unexpected
+     * NOTE: DO NOT USE THE asXMLString method. It uses the platform's default charset, which can lead to unexpected
      * problems with the output.
      *
      * See https://drivenbydata.atlassian.net/browse/EASY-984

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/FOXML.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/FOXML.scala
@@ -22,7 +22,13 @@ import scala.xml.{Elem, NodeSeq, XML}
 object FOXML {
 
   def getDatasetFOXML(ownerId: String, emd: EasyMetadata): String = {
-    val dc = XML.loadString(emd.getDublinCoreMetadata.asXMLString())
+    /*
+     * NOTE: DO NOT USER THE asXMLString method. It uses the platform's default charset, which can lead to unexpected
+     * problems with the output.
+     *
+     * See https://drivenbydata.atlassian.net/browse/EASY-984
+     */
+    val dc = XML.load(emd.getDublinCoreMetadata.asXMLInputStream())
     getFOXML(emd.getPreferredTitle, ownerId, dc).toString()
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
@@ -21,6 +21,8 @@ import nl.knaw.dans.easy.stage.Settings
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
 
+import scala.util.Try
+
 object JSON {
   val HAS_DOI = "http://dans.knaw.nl/ontologies/relations#hasDoi"
   val HAS_PID = "http://dans.knaw.nl/ontologies/relations#hasPid"
@@ -29,7 +31,11 @@ object JSON {
   val IS_SUBORDINATE_TO = "http://dans.knaw.nl/ontologies/relations#isSubordinateTo"
   val STORED_IN_DARKARCHIVE = "http://dans.knaw.nl/ontologies/relations#storedInDarkArchive"
 
-  def createDatasetCfg(mimeType: Option[String], audiences: Seq[String])(implicit s: Settings): String = {
+  def createDatasetCfg(mimeType: Option[String], audiences: Seq[String])(implicit s: Settings): Try[String]= Try {
+    def checkProvided(name: String, v: Option[String]) = if(v.isEmpty) throw new IllegalStateException(s"$name must be provided")
+    checkProvided("DOI", s.DOI)
+    checkProvided("URN", s.URN)
+    mimeType.toList.map(_ => checkProvided("Additional license MIME-type", mimeType))
 
     val datastreams =
       List(

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.stage.lib
 
 import java.io.File
 
+import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Try}
@@ -25,7 +26,15 @@ object Util {
   val log = LoggerFactory.getLogger(getClass)
 
   def writeToFile(f: File, s: String): Try[Unit] =
-    Try { scala.tools.nsc.io.File(f).writeAll(s) }
+    /*
+     * DO NOT USE THE SCALA File CLASS TO WRITE THE XML.
+     * It does not have a Charset parameter, so it will try to write in the
+     * platform's default Charset, resulting in question marks for characters that
+     * are not in that Charset.
+     *
+     * See: https://drivenbydata.atlassian.net/browse/EASY-984
+     */
+    Try { FileUtils.write(f, s, "UTF-8")}
 
   def writeJsonCfg(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "cfg.json"), content)
@@ -41,6 +50,9 @@ object Util {
 
   def writeEMD(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EMD"), content)
+
+  def writeDC(sdoDir: File, content: String): Try[Unit] =
+    writeToFile(new File(sdoDir, "DC"), content)
 
   def writeFileMetadata(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EASY_FILE_METADATA"), content)

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
@@ -51,9 +51,6 @@ object Util {
   def writeEMD(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EMD"), content)
 
-  def writeDC(sdoDir: File, content: String): Try[Unit] =
-    writeToFile(new File(sdoDir, "DC"), content)
-
   def writeFileMetadata(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EASY_FILE_METADATA"), content)
 


### PR DESCRIPTION
- Addition to previous fix. The DC-datastream (which is provided inline in the fo.xml) was written
  with another legacy method that is platform dependent with respect to the charset used.
- Removed the codependency check for the command line arguments urn and doi. They are not codependent,
  actually they cannot be left out. Added a check in JSON for this. Leaving out the DOI or URN led
  to the key-value pair simply being omitted in the JSON.
