### PR TITLE
EASY-986. Using dc:title for filename.

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -90,13 +90,15 @@ object EasyStageDataset {
     for {
       sdoDir <- mkdirSafe(getSDODir(file))
       mime <- readMimeType(getBagRelativePath(file).toString)
-      _ <- EasyStageFileItem.createFileSdo(sdoDir, relativePath, "objectSDO" -> parentSDO
+      title <- readTitle(getBagRelativePath(file).toString)
+      _ <- EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> parentSDO
       )(FileItemSettings(
         sdoSetDir = s.sdoSetDir,
         ownerId = s.ownerId,
         pathInDataset = new File(relativePath),
         size = Some(file.length),
-        format = Some(mime)
+        format = Some(mime),
+        title = title
       ))
     } yield ()
   }
@@ -106,7 +108,7 @@ object EasyStageDataset {
     val relativePath= getDatasetRelativePath(folder).toString
     for {
       sdoDir <- mkdirSafe(getSDODir(folder))
-      fis     = FileItemSettings(s.sdoSetDir, s.ownerId, getDatasetRelativePath(folder).toFile, None, None)
+      fis     = FileItemSettings(s.sdoSetDir, s.ownerId, getDatasetRelativePath(folder).toFile, None, None, None)
       _      <- EasyStageFileItem.createFolderSdo(sdoDir, relativePath, "objectSDO" -> parentSDO)(fis)
     } yield ()
   }

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -20,7 +20,7 @@ import java.io.File
 import nl.knaw.dans.easy.stage.Settings
 
 import scala.util.{Failure, Success, Try}
-import scala.xml.{Elem, XML}
+import scala.xml.{NodeSeq, Elem, XML}
 
 object Util {
 
@@ -55,6 +55,16 @@ object Util {
     if (mimes.size != 1)
       throw new scala.RuntimeException(s"Filepath [$filePath] doesn't exist in files.xml, or isn't unique.")
     mimes(0).text
+  }
+
+  def readTitle(filePath: String)(implicit s: Settings): Try[Option[String]] = Try {
+    val titles = for {
+      file <- loadXML("metadata/files.xml") \\ "files" \ "file"
+      if (file \ "@filepath").text == filePath
+      title <- file \ "title"
+    } yield title
+    if(titles.size == 1) Option(titles(0).text)
+    else None
   }
 
   def readAudiences()(implicit s: Settings): Try[Seq[String]] = Try {

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
@@ -15,13 +15,18 @@
  */
 package nl.knaw.dans.easy.stage.fileitem
 
+import java.io.File
+
 import scala.util.Try
 
 object EasyFileMetadata {
   def apply(s: FileItemSettings): Try[String] = Try {
+      val parentPath = s.pathInDataset.get.getParentFile
+      val fileName = s.title.getOrElse(s.pathInDataset.get.getName)
+
       <fimd:file-item-md xmlns:fimd="http://easy.dans.knaw.nl/easy/file-item-md/" version="0.1" >
-        <name>{s.pathInDataset.get.getName}</name>
-        <path>{s.pathInDataset.get}</path>
+        <name>{fileName}</name>
+        <path>{new File(parentPath, fileName)}</path>
         <mimeType>{s.format.get}</mimeType>
         <size>{s.size.get}</size>
         <creatorRole>{s.creatorRole}</creatorRole>

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
@@ -28,6 +28,7 @@ case class FileItemSettings (sdoSetDir: Option[File],
                                      size: Option[Long],
                                      ownerId: String = props.getString("owner"),
                                      pathInDataset: Option[File],
+                                     title:  Option[String] = None,
                                      format: Option[String] = None,
 
                                      // as in SDO/*/EASY_FILE_METADATA
@@ -46,6 +47,7 @@ object FileItemSettings {
             ownerId: String,
             pathInDataset: File,
             format: Option[String],
+            title: Option[String],
             size: Option[Long]
            ) =
     new FileItemSettings(
@@ -56,6 +58,7 @@ object FileItemSettings {
       ownerId = ownerId,
       pathInDataset = Some(pathInDataset),
       format = format,
+      title = title,
       subordinate = "objectSDO" -> "dataset"
     )
 


### PR DESCRIPTION
When staging a dataset, for each file that is staged the program now checks if it has exactly one `dcterm:title` element in the `metadata/files.xml`. If it does, this title is used as the file name. 

Note that no check is done yet for name clashes. This will require some refactoring of the code. I will create a new issue for that.

@lindareijnhoudt @PaulBoon @ekoi @rvanheest please review
