### PR TITLE
EASY-1006 (stage dataset/file-item)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ ARGUMENTS for easy-stage-fileItem
       -c, --creator-role  <arg>          specifies the role of the file item creator;
                                          either one of [ARCHIVIST,DEPOSITOR]
                                          (default = DEPOSITOR)
+      -l, --file-location  <arg>         The file to be staged (only required for
+                                         copying in case of non-mendeley use case)
       -m, --is-mendeley                  Stage the dataset as a "mendeley dataset"
           --owner-id  <arg>              specifies the id of the owner/creator of the
                                          file item (defaults to the one configured in

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x 
 SYNOPSIS
 --------
 
-    easy-stage-dataset -t <submission-timestamp> -u <urn> -d <doi> [ -o ] \
+    easy-stage-dataset -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -m ] \
                           <EASY-bag> <staged-digital-object-set>
 
     easy-stage-file-item [<options>...] <staged-digital-object-set>
@@ -40,6 +40,7 @@ the command `easy-stage-file-item`. It executes step 3 to stage one or more file
 ARGUMENTS for easy-stage-dataset
 --------------------------------
 
+     -m, --dataset-is-mendeley-dataset   Stage the dataset as a "mendeley dataset"
      -d, --doi  <arg>                    The DOI to assign to the new dataset in EASY
      -o, --doi-is-other-access-doi       Stage the provided DOI as an "other access
                                          DOI"
@@ -79,6 +80,7 @@ ARGUMENTS for easy-stage-fileItem
       -c, --creator-role  <arg>          specifies the role of the file item creator;
                                          either one of [ARCHIVIST,DEPOSITOR]
                                          (default = DEPOSITOR)
+      -m, --is-mendeley                  Stage the dataset as a "mendeley dataset"
           --owner-id  <arg>              specifies the id of the owner/creator of the
                                          file item (defaults to the one configured in
                                          the application configuration file)

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -49,28 +49,28 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
     new File(f)
   })
 
-  lazy val submissionTimestamp: ScallopOption[DateTime] = opt[DateTime](
+  val submissionTimestamp: ScallopOption[DateTime] = opt[DateTime](
     name = "submission-timestamp", short = 't',
     descr = "Timestamp in ISO8601 format")
-  lazy val urn: ScallopOption[String] = opt[String](
+  val urn: ScallopOption[String] = opt[String](
     name = "urn", short = 'u',
     descr = "The URN to assign to the new dataset in EASY")
-  lazy val doi: ScallopOption[String] = opt[String](
+  val doi: ScallopOption[String] = opt[String](
     name = "doi", short = 'd',
     descr = "The DOI to assign to the new dataset in EASY")
-  lazy val otherAccessDOI = opt[Boolean](
+  val otherAccessDOI = opt[Boolean](
     name = "doi-is-other-access-doi", short = 'o',
     descr = """Stage the provided DOI as an "other access DOI"""",
     default = Some(false))
-  lazy val isMendeley = opt[Boolean](
+  val isMendeley = opt[Boolean](
     name = "dataset-is-mendeley-dataset", short = 'm',
     descr = """Stage the dataset as a "mendeley dataset"""",
     default = Some(false))
-  lazy val bag = trailArg[File](
+  val bag = trailArg[File](
     name = "EASY-bag",
     descr = "Bag with extra metadata for EASY to be staged for ingest into Fedora",
     required = true)(shouldExist)
-  lazy val sdoSet = trailArg[File](
+  val sdoSet = trailArg[File](
     name = "staged-digital-object-set",
     descr = "The resulting Staged Digital Object directory (will be created if it does not exist)",
     required = true)(mayNotExist)

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -49,28 +49,28 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
     new File(f)
   })
 
-  val submissionTimestamp: ScallopOption[DateTime] = opt[DateTime](
+  lazy val submissionTimestamp: ScallopOption[DateTime] = opt[DateTime](
     name = "submission-timestamp", short = 't',
     descr = "Timestamp in ISO8601 format")
-  val urn: ScallopOption[String] = opt[String](
+  lazy val urn: ScallopOption[String] = opt[String](
     name = "urn", short = 'u',
     descr = "The URN to assign to the new dataset in EASY")
-  val doi: ScallopOption[String] = opt[String](
+  lazy val doi: ScallopOption[String] = opt[String](
     name = "doi", short = 'd',
     descr = "The DOI to assign to the new dataset in EASY")
-  val otherAccessDOI = opt[Boolean](
+  lazy val otherAccessDOI = opt[Boolean](
     name = "doi-is-other-access-doi", short = 'o',
     descr = """Stage the provided DOI as an "other access DOI"""",
     default = Some(false))
-  val isMendeley = opt[Boolean](
+  lazy val isMendeley = opt[Boolean](
     name = "dataset-is-mendeley-dataset", short = 'm',
     descr = """Stage the dataset as a "mendeley dataset"""",
     default = Some(false))
-  val bag = trailArg[File](
+  lazy val bag = trailArg[File](
     name = "EASY-bag",
     descr = "Bag with extra metadata for EASY to be staged for ingest into Fedora",
     required = true)(shouldExist)
-  val sdoSet = trailArg[File](
+  lazy val sdoSet = trailArg[File](
     name = "staged-digital-object-set",
     descr = "The resulting Staged Digital Object directory (will be created if it does not exist)",
     required = true)(mayNotExist)

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -33,7 +33,7 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
            |
            |Usage:
            |
-           | $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] \\
+           | $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -m ] \\
            | ${_________}    <EASY-bag> <staged-digital-object-set>
            |
            |Options:
@@ -61,6 +61,10 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
   val otherAccessDOI = opt[Boolean](
     name = "doi-is-other-access-doi", short = 'o',
     descr = """Stage the provided DOI as an "other access DOI"""",
+    default = Some(false))
+  val isMendeley = opt[Boolean](
+    name = "dataset-is-mendeley-dataset", short = 'm',
+    descr = """Stage the dataset as a "mendeley dataset"""",
     default = Some(false))
   val bag = trailArg[File](
     name = "EASY-bag",

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -97,6 +97,7 @@ object EasyStageDataset {
         ownerId = s.ownerId,
         pathInDataset = new File(relativePath),
         size = Some(file.length),
+        isMendeley = Some(s.isMendeley),
         format = Some(mime),
         title = title
       ))
@@ -108,7 +109,7 @@ object EasyStageDataset {
     val relativePath= getDatasetRelativePath(folder).toString
     for {
       sdoDir <- mkdirSafe(getSDODir(folder))
-      fis     = FileItemSettings(s.sdoSetDir, s.ownerId, getDatasetRelativePath(folder).toFile, None, None, None)
+      fis     = FileItemSettings(s.sdoSetDir, s.ownerId, getDatasetRelativePath(folder).toFile, None, None, None, None)
       _      <- EasyStageFileItem.createFolderSdo(sdoDir, relativePath, "objectSDO" -> parentSDO)(fis)
     } yield ()
   }

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -94,6 +94,7 @@ object EasyStageDataset {
       _ <- EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> parentSDO
       )(FileItemSettings(
         sdoSetDir = s.sdoSetDir,
+        file = file,
         ownerId = s.ownerId,
         pathInDataset = new File(relativePath),
         size = Some(file.length),
@@ -109,7 +110,7 @@ object EasyStageDataset {
     val relativePath= getDatasetRelativePath(folder).toString
     for {
       sdoDir <- mkdirSafe(getSDODir(folder))
-      fis     = FileItemSettings(s.sdoSetDir, s.ownerId, getDatasetRelativePath(folder).toFile, None, None, None, None)
+      fis     = FileItemSettings(s.sdoSetDir, null, s.ownerId, getDatasetRelativePath(folder).toFile, None, None, None, None)
       _      <- EasyStageFileItem.createFolderSdo(sdoDir, relativePath, "objectSDO" -> parentSDO)(fis)
     } yield ()
   }

--- a/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
@@ -30,6 +30,7 @@ case class Settings(ownerId: String,
                     URN: Option[String] = None,
                     DOI: Option[String] = None,
                     otherAccessDOI: Boolean = false,
+                    isMendeley: Boolean,
                     fedoraUser: String,
                     fedoraPassword: String,
                     fedoraUrl: URL) {
@@ -49,6 +50,7 @@ object Settings {
             URN: String,
             DOI: String,
             otherAccessDOI: Boolean,
+            isMendeley: Boolean,
             fedoraUser: String,
             fedoraPassword: String,
             fedoraUrl: URL) =
@@ -59,6 +61,7 @@ object Settings {
       URN = Some(URN),
       DOI = Some(DOI),
       otherAccessDOI = otherAccessDOI,
+      isMendeley = isMendeley,
       fedoraUser = fedoraUser,
       fedoraPassword = fedoraPassword,
       fedoraUrl = fedoraUrl)
@@ -72,6 +75,7 @@ object Settings {
       URN = conf.urn.get,
       DOI = conf.doi.get,
       otherAccessDOI = conf.otherAccessDOI(),
+      isMendeley = conf.isMendeley(),
       fedoraUser = props.getString("fcrepo.user"),
       fedoraPassword = props.getString("fcrepo.password"),
       fedoraUrl = new URL(props.getString("fcrepo.url")))

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
@@ -22,14 +22,14 @@ import nl.knaw.dans.easy.stage.Settings
 import nl.knaw.dans.easy.stage.lib.Constants
 import org.apache.commons.io.FileUtils
 
-import scala.util.{Failure, Success, Try}
-import scala.xml.{MetaData, Node, Elem, XML}
+import scala.util.{Success, Try}
+import scala.xml.{Node, Elem, XML}
 
 object AdditionalLicense {
   type MimeType = String
 
   def createOptionally(sdo: File)(implicit s: Settings): Try[Option[MimeType]] =
-   if((getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "license").size == 0) Success(None)
+   if((getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "license").isEmpty) Success(None)
    else create(sdo).map(m => Some(m))
 
   def create(sdo: File)(implicit s: Settings): Try[MimeType] =
@@ -42,14 +42,14 @@ object AdditionalLicense {
 
   def getAdditionalLicenseTemplate()(implicit s: Settings): Try[(String, MimeType)] = Try {
     val licenses = getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "license"
-    licenses.toSeq match {
+    licenses match {
       case Seq(license) =>
           if(hasXsiType(license, "http://purl.org/dc/terms/", "URI")) {
             val licenseTemplateFile = s.licenses(license.text)
             (FileUtils.readFileToString(licenseTemplateFile, "UTF-8"), getLicenseMimeType(licenseTemplateFile.getName))
           }
           else (license.text, "text/plain")
-      case licenses => throw new RuntimeException(s"Found ${licenses.size} dcterms:license elements. There should be exactly one")
+      case lics => throw new RuntimeException(s"Found ${lics.size} dcterms:license elements. There should be exactly one")
     }
   }
 
@@ -89,7 +89,7 @@ object AdditionalLicense {
 
   def getRightsHolder()(implicit s: Settings): Try[String] = Try {
     val rightsHolders = getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "rightsHolder"
-    if(rightsHolders.size == 0) throw new RuntimeException("No dcterms:rightsHolder element found. There should be at least one")
+    if(rightsHolders.isEmpty) throw new RuntimeException("No dcterms:rightsHolder element found. There should be at least one")
     else rightsHolders.toList.map(_.text).mkString(", ")
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
@@ -16,20 +16,20 @@
 package nl.knaw.dans.easy.stage.dataset
 
 import java.io.File
-import org.joda.time.DateTime
 
 import nl.knaw.dans.easy.stage.Settings
 import nl.knaw.dans.easy.stage.lib.Constants
 import org.apache.commons.io.FileUtils
+import org.joda.time.DateTime
 
-import scala.util.{Failure, Success, Try}
-import scala.xml.{MetaData, Node, Elem, XML}
+import scala.util.{Success, Try}
+import scala.xml.{Elem, Node, XML}
 
 object AdditionalLicense {
   type MimeType = String
 
   def createOptionally(sdo: File)(implicit s: Settings): Try[Option[MimeType]] =
-   if((getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "license").size == 0) Success(None)
+   if((getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "license").isEmpty) Success(None)
    else create(sdo).map(m => Some(m))
 
   def create(sdo: File)(implicit s: Settings): Try[MimeType] =
@@ -42,14 +42,14 @@ object AdditionalLicense {
 
   def getAdditionalLicenseTemplate()(implicit s: Settings): Try[(String, MimeType)] = Try {
     val licenses = getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "license"
-    licenses.toSeq match {
+    licenses match {
       case Seq(license) =>
           if(hasXsiType(license, "http://purl.org/dc/terms/", "URI")) {
             val licenseTemplateFile = s.licenses(license.text)
             (FileUtils.readFileToString(licenseTemplateFile, "UTF-8"), getLicenseMimeType(licenseTemplateFile.getName))
           }
           else (license.text, "text/plain")
-      case licenses => throw new RuntimeException(s"Found ${licenses.size} dcterms:license elements. There should be exactly one")
+      case lics => throw new RuntimeException(s"Found ${lics.size} dcterms:license elements. There should be exactly one")
     }
   }
 
@@ -89,7 +89,7 @@ object AdditionalLicense {
 
   def getRightsHolder()(implicit s: Settings): Try[String] = Try {
     val rightsHolders = getDdmXml().get \\ "DDM" \ "dcmiMetadata" \ "rightsHolder"
-    if(rightsHolders.size == 0) throw new RuntimeException("No dcterms:rightsHolder element found. There should be at least one")
+    if(rightsHolders.isEmpty) throw new RuntimeException("No dcterms:rightsHolder element found. There should be at least one")
     else rightsHolders.toList.map(_.text).mkString(", ")
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/PRSQL.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/PRSQL.scala
@@ -15,6 +15,14 @@
  */
 package nl.knaw.dans.easy.stage.dataset
 
+import java.io.File
+
+import nl.knaw.dans.easy.stage.lib.Constants
+import nl.knaw.dans.easy.stage.lib.Constants._
+import nl.knaw.dans.easy.stage.lib.Util._
+
+import scala.util.Try
+
 object PRSQL {
 
   def create(): String = {

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/PRSQL.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/PRSQL.scala
@@ -15,14 +15,6 @@
  */
 package nl.knaw.dans.easy.stage.dataset
 
-import java.io.File
-
-import nl.knaw.dans.easy.stage.lib.Constants
-import nl.knaw.dans.easy.stage.lib.Constants._
-import nl.knaw.dans.easy.stage.lib.Util._
-
-import scala.util.Try
-
 object PRSQL {
 
   def create(): String = {

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -20,7 +20,7 @@ import java.io.File
 import nl.knaw.dans.easy.stage.Settings
 
 import scala.util.{Failure, Success, Try}
-import scala.xml.{Elem, XML}
+import scala.xml.{NodeSeq, Elem, XML}
 
 object Util {
 
@@ -28,8 +28,8 @@ object Util {
     extends RuntimeException(throwables.foldLeft("Multiple failures:")((msg, t) => s"$msg\n${t.getClass}: ${t.getMessage}, ${getFirstDansFrame(t)}"))
 
   private def getFirstDansFrame(t: Throwable): String = {
-    if(t.getStackTrace.length > 0) {
-      val st = t.getStackTrace
+    if(t.getStackTrace().length > 0) {
+      val st = t.getStackTrace()
       st.find(_.getClassName.contains("nl.knaw.dans")) match {
         case Some(el) => s"${el.getClassName}.${el.getMethodName} (${el.getFileName}, ${el.getLineNumber})"
         case None => "<No DANS code in stacktrace ?>"

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -20,7 +20,7 @@ import java.io.File
 import nl.knaw.dans.easy.stage.Settings
 
 import scala.util.{Failure, Success, Try}
-import scala.xml.{NodeSeq, Elem, XML}
+import scala.xml.{Elem, XML}
 
 object Util {
 
@@ -28,8 +28,8 @@ object Util {
     extends RuntimeException(throwables.foldLeft("Multiple failures:")((msg, t) => s"$msg\n${t.getClass}: ${t.getMessage}, ${getFirstDansFrame(t)}"))
 
   private def getFirstDansFrame(t: Throwable): String = {
-    if(t.getStackTrace().length > 0) {
-      val st = t.getStackTrace()
+    if(t.getStackTrace.length > 0) {
+      val st = t.getStackTrace
       st.find(_.getClassName.contains("nl.knaw.dans")) match {
         case Some(el) => s"${el.getClassName}.${el.getMethodName} (${el.getFileName}, ${el.getLineNumber})"
         case None => "<No DANS code in stacktrace ?>"

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.sql.{DriverManager, PreparedStatement}
 
 import nl.knaw.dans.easy.stage.lib.Props.props
+import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFilesAndFolders.scala
@@ -20,7 +20,6 @@ import java.io.File
 import java.sql.{DriverManager, PreparedStatement}
 
 import nl.knaw.dans.easy.stage.lib.Props.props
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -121,7 +121,7 @@ object EasyStageFileItem {
       _            <- writeFoxml(sdoDir, foxmlContent)
       fmd          <- EasyFileMetadata(s)
       _            <- writeFileMetadata(sdoDir, fmd)
-      _            <- s.isMendeley.filter(identity).flatMap(_ => s.file.map(copyFile(sdoDir, _))).getOrElse(Success(Unit))
+      _            <- s.isMendeley.filter(b => !b).flatMap(_ => s.file.map(copyFile(sdoDir, _))).getOrElse(Success(Unit))
     } yield ()
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -121,6 +121,7 @@ object EasyStageFileItem {
       _            <- writeFoxml(sdoDir, foxmlContent)
       fmd          <- EasyFileMetadata(s)
       _            <- writeFileMetadata(sdoDir, fmd)
+      _            <- s.isMendeley.filter(identity).flatMap(_ => s.file.map(copyFile(sdoDir, _))).getOrElse(Success(Unit))
     } yield ()
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -55,13 +55,13 @@ object EasyStageFileItem {
       val trailArgs = Seq(conf.sdoSetDir.apply().toString)
       CSV(conf.csvFile.apply(), conf.longOptionNames).map {
         case (csv, warning) =>
-          warning.map(msg => log.warn(msg))
+          warning.foreach(log.warn)
           val rows = csv.getRows
           if (rows.isEmpty) log.warn(s"Empty CSV file")
-          rows.map{options =>
+          rows.map(options => {
             log.info("Options: "+options.mkString(" "))
             FileItemSettings(new FileItemConf(options ++ trailArgs))
-          }
+          })
       }
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -55,13 +55,14 @@ object EasyStageFileItem {
       val trailArgs = Seq(conf.sdoSetDir.apply().toString)
       CSV(conf.csvFile.apply(), conf.longOptionNames).map {
         case (csv, warning) =>
-          warning.map(msg => log.warn(msg))
+          warning.foreach(log.warn)
+
           val rows = csv.getRows
           if (rows.isEmpty) log.warn(s"Empty CSV file")
-          rows.map{options =>
+          rows.map(options => {
             log.info("Options: "+options.mkString(" "))
             FileItemSettings(new FileItemConf(options ++ trailArgs))
-          }
+          })
       }
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -55,14 +55,13 @@ object EasyStageFileItem {
       val trailArgs = Seq(conf.sdoSetDir.apply().toString)
       CSV(conf.csvFile.apply(), conf.longOptionNames).map {
         case (csv, warning) =>
-          warning.foreach(log.warn)
-
+          warning.map(msg => log.warn(msg))
           val rows = csv.getRows
           if (rows.isEmpty) log.warn(s"Empty CSV file")
-          rows.map(options => {
+          rows.map{options =>
             log.info("Options: "+options.mkString(" "))
             FileItemSettings(new FileItemConf(options ++ trailArgs))
-          })
+          }
       }
     }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -64,6 +64,9 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
   val size = opt[Long](
     name = "size",
     descr = "Size in bytes of the file data")
+  val file = opt[File](
+    name = "file-location", short = 'l',
+    descr = "The file to be staged (only required for copying in case of non-mendeley use case)")(shouldBeFile)
   val isMendeley = opt[Boolean](
     name = "is-mendeley", short = 'm',
     descr = """Stage the dataset as a "mendeley dataset"""",

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -110,6 +110,7 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
   dependsOnAll(datasetId,List(pathInDataset,size,dsLocation))
   conflicts(csvFile,List(datasetId,pathInDataset,size,dsLocation))
   requireOne(csvFile,datasetId)
+  mutuallyExclusive(isMendeley, file)
 
   validate(accessibleTo) (s => validateValue(s, accessCategories))
   validate(visibleTo) (s => validateValue(s, accessCategories))

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -50,56 +50,55 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
     if (!new File(f).isFile) throw new IllegalArgumentException(s"$f is not an existing file")
     new File(f)
   })
-
-  lazy val pathInDataset = opt[File](
+  val pathInDataset = opt[File](
     name = "path-in-dataset", short = 'p',
     descr = "the path that the file should get in the dataset, a staged digital object is created" +
       " for the file and the ancestor folders that don't yet exist in the dataset")(mayNotExist)
-  lazy val format = opt[String](
+  val format = opt[String](
     name = "format", short = 'f',
     descr = "dcterms property format, the mime type of the file",
     default = Some(defaultFormat))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultFormat)))
-  lazy val dsLocation = opt[URL](
+  val dsLocation = opt[URL](
     name = "datastream-location",
     descr = "http URL to redirect to")(httpUrl)
-  lazy val size = opt[Long](
+  val size = opt[Long](
     name = "size",
     descr = "Size in bytes of the file data")
-  lazy val file = opt[File](
+  val file = opt[File](
     name = "file-location", short = 'l',
     descr = "The file to be staged (only required for copying in case of non-mendeley use case)")(shouldBeFile)
-  lazy val isMendeley = opt[Boolean](
+  val isMendeley = opt[Boolean](
     name = "is-mendeley", short = 'm',
     descr = """Stage the dataset as a "mendeley dataset"""",
     default = Some(false))
-  lazy val datasetId = opt[String](
+  val datasetId = opt[String](
     name = "dataset-id", short = 'i',
     descr = "id of the dataset in Fedora that should receive the file to stage (requires file-path). " +
      "If omitted the trailing argument csv-file is required")
-  lazy val accessibleTo = opt[String] (
+  val accessibleTo = opt[String] (
     name = "accessible-to", short = 'a',
     descr = s"specifies the accessibility of the file item; either one of [${accessCategories.mkString(",")}]",
     default = Some(defaultAccessibleTo))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultAccessibleTo)))
-  lazy val visibleTo = opt[String] (
+  val visibleTo = opt[String] (
     name = "visible-to", short = 'v',
     descr = s"specifies the visibility of the file item; either one of [${accessCategories.mkString(",")}",
     default = Some(defaultVisibleTo))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultVisibleTo)))
-  lazy val creatorRole = opt[String](
+  val creatorRole = opt[String](
     name = "creator-role", short = 'c',
     descr = s"specifies the role of the file item creator; either one of [${creatorRoles.mkString(",")}]",
     default = Some(defaultCreatorRole))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultCreatorRole)))
 
-  lazy val ownerId = opt[String](
+  val ownerId = opt[String](
     name = "owner-id", noshort = true,
     descr = "specifies the id of the owner/creator of the file item " +
       "(defaults to the one configured in the application configuration file)"
   )
-  lazy val csvFile = trailArg[File](
+  val csvFile = trailArg[File](
     name = "csv-file",
     descr = "a comma separated file with one column for each option " +
      "(additional columns are ignored) and one set of options per line",
     required = false)(shouldBeFile)
-  lazy val sdoSetDir = trailArg[File](
+  val sdoSetDir = trailArg[File](
     name = "staged-digital-object-sets",
     descr = "The resulting directory with Staged Digital Object directories per dataset" +
       " (will be created if it does not exist)",
@@ -116,7 +115,7 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
   validate(visibleTo) (s => validateValue(s, accessCategories))
   validate(creatorRole) (s => validateValue(s, creatorRoles))
 
-  lazy val longOptionNames = builder.opts.filter(!_.isInstanceOf[TrailingArgsOption]).map(_.name)
+  val longOptionNames = builder.opts.filter(!_.isInstanceOf[TrailingArgsOption]).map(_.name)
 
   override def toString = builder.args.mkString(", ")
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -50,55 +50,56 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
     if (!new File(f).isFile) throw new IllegalArgumentException(s"$f is not an existing file")
     new File(f)
   })
-  val pathInDataset = opt[File](
+
+  lazy val pathInDataset = opt[File](
     name = "path-in-dataset", short = 'p',
     descr = "the path that the file should get in the dataset, a staged digital object is created" +
       " for the file and the ancestor folders that don't yet exist in the dataset")(mayNotExist)
-  val format = opt[String](
+  lazy val format = opt[String](
     name = "format", short = 'f',
     descr = "dcterms property format, the mime type of the file",
     default = Some(defaultFormat))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultFormat)))
-  val dsLocation = opt[URL](
+  lazy val dsLocation = opt[URL](
     name = "datastream-location",
     descr = "http URL to redirect to")(httpUrl)
-  val size = opt[Long](
+  lazy val size = opt[Long](
     name = "size",
     descr = "Size in bytes of the file data")
-  val file = opt[File](
+  lazy val file = opt[File](
     name = "file-location", short = 'l',
     descr = "The file to be staged (only required for copying in case of non-mendeley use case)")(shouldBeFile)
-  val isMendeley = opt[Boolean](
+  lazy val isMendeley = opt[Boolean](
     name = "is-mendeley", short = 'm',
     descr = """Stage the dataset as a "mendeley dataset"""",
     default = Some(false))
-  val datasetId = opt[String](
+  lazy val datasetId = opt[String](
     name = "dataset-id", short = 'i',
     descr = "id of the dataset in Fedora that should receive the file to stage (requires file-path). " +
      "If omitted the trailing argument csv-file is required")
-  val accessibleTo = opt[String] (
+  lazy val accessibleTo = opt[String] (
     name = "accessible-to", short = 'a',
     descr = s"specifies the accessibility of the file item; either one of [${accessCategories.mkString(",")}]",
     default = Some(defaultAccessibleTo))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultAccessibleTo)))
-  val visibleTo = opt[String] (
+  lazy val visibleTo = opt[String] (
     name = "visible-to", short = 'v',
     descr = s"specifies the visibility of the file item; either one of [${accessCategories.mkString(",")}",
     default = Some(defaultVisibleTo))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultVisibleTo)))
-  val creatorRole = opt[String](
+  lazy val creatorRole = opt[String](
     name = "creator-role", short = 'c',
     descr = s"specifies the role of the file item creator; either one of [${creatorRoles.mkString(",")}]",
     default = Some(defaultCreatorRole))(singleArgConverter[String](conv = replaceEmptyValueWith(defaultCreatorRole)))
 
-  val ownerId = opt[String](
+  lazy val ownerId = opt[String](
     name = "owner-id", noshort = true,
     descr = "specifies the id of the owner/creator of the file item " +
       "(defaults to the one configured in the application configuration file)"
   )
-  val csvFile = trailArg[File](
+  lazy val csvFile = trailArg[File](
     name = "csv-file",
     descr = "a comma separated file with one column for each option " +
      "(additional columns are ignored) and one set of options per line",
     required = false)(shouldBeFile)
-  val sdoSetDir = trailArg[File](
+  lazy val sdoSetDir = trailArg[File](
     name = "staged-digital-object-sets",
     descr = "The resulting directory with Staged Digital Object directories per dataset" +
       " (will be created if it does not exist)",
@@ -115,7 +116,7 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
   validate(visibleTo) (s => validateValue(s, accessCategories))
   validate(creatorRole) (s => validateValue(s, creatorRoles))
 
-  val longOptionNames = builder.opts.filter(!_.isInstanceOf[TrailingArgsOption]).map(_.name)
+  lazy val longOptionNames = builder.opts.filter(!_.isInstanceOf[TrailingArgsOption]).map(_.name)
 
   override def toString = builder.args.mkString(", ")
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -64,6 +64,10 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
   val size = opt[Long](
     name = "size",
     descr = "Size in bytes of the file data")
+  val isMendeley = opt[Boolean](
+    name = "is-mendeley", short = 'm',
+    descr = """Stage the dataset as a "mendeley dataset"""",
+    default = Some(false))
   val datasetId = opt[String](
     name = "dataset-id", short = 'i',
     descr = "id of the dataset in Fedora that should receive the file to stage (requires file-path). " +

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
@@ -22,13 +22,12 @@ import nl.knaw.dans.easy.stage.fileitem.FileItemSettings._
 import nl.knaw.dans.easy.stage.lib.Fedora
 import nl.knaw.dans.easy.stage.lib.Props.props
 
-import scala.util.Try
-
 case class FileItemSettings (sdoSetDir: Option[File],
                              datasetId: Option[String],
                              datastreamLocation: Option[URL],
                              unsetUrl: URL = new URL(props.getString("redirect-unset-url")),
                              size: Option[Long],
+                             isMendeley: Option[Boolean],
                              ownerId: String = props.getString("owner"),
                              pathInDataset: Option[File],
                              title:  Option[String] = None,
@@ -64,7 +63,8 @@ object FileItemSettings {
             pathInDataset: File,
             format: Option[String],
             title: Option[String],
-            size: Option[Long]
+            size: Option[Long],
+            isMendeley: Option[Boolean]
            ) =
     // no need to catch exceptions thrown by the constructor as the defaults take care of valid values
     new FileItemSettings(
@@ -72,6 +72,7 @@ object FileItemSettings {
       datasetId = None,
       datastreamLocation = None,
       size = size,
+      isMendeley = isMendeley,
       ownerId = ownerId,
       pathInDataset = Some(pathInDataset),
       format = format,
@@ -86,6 +87,7 @@ object FileItemSettings {
       sdoSetDir = conf.sdoSetDir.get,
       datastreamLocation = conf.dsLocation.get,
       size = conf.size.get,
+      isMendeley = conf.isMendeley.get,
       accessibleTo = conf.accessibleTo(),
       visibleTo = conf.visibleTo(),
       creatorRole = conf.creatorRole(),

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
@@ -23,6 +23,7 @@ import nl.knaw.dans.easy.stage.lib.Fedora
 import nl.knaw.dans.easy.stage.lib.Props.props
 
 case class FileItemSettings (sdoSetDir: Option[File],
+                             file: Option[File],
                              datasetId: Option[String],
                              datastreamLocation: Option[URL],
                              unsetUrl: URL = new URL(props.getString("redirect-unset-url")),
@@ -59,6 +60,7 @@ object FileItemSettings {
 
   /** new file or folder for a new dataset */
   def apply(sdoSetDir: File,
+            file: File,
             ownerId: String,
             pathInDataset: File,
             format: Option[String],
@@ -69,6 +71,7 @@ object FileItemSettings {
     // no need to catch exceptions thrown by the constructor as the defaults take care of valid values
     new FileItemSettings(
       sdoSetDir = Some(sdoSetDir),
+      file = Some(file),
       datasetId = None,
       datastreamLocation = None,
       size = size,
@@ -85,6 +88,7 @@ object FileItemSettings {
     // no need to catch exceptions thrown by the constructor as FileItemConf performs the same checks
     new FileItemSettings(
       sdoSetDir = conf.sdoSetDir.get,
+      file = conf.file.get,
       datastreamLocation = conf.dsLocation.get,
       size = conf.size.get,
       isMendeley = conf.isMendeley.get,

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/CSV.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/CSV.scala
@@ -53,7 +53,7 @@ object CSV {
 
   /** @return (new instance, warning) */
   def apply(in: InputStream, requiredHeaders: Seq[String]): Try[(CSV, Option[String])] =
-    if (requiredHeaders.map(_.toLowerCase)!=requiredHeaders)
+    if (requiredHeaders.map(_.toLowerCase) != requiredHeaders)
       Failure(new Exception("required headers with uppercase are not supported " +
         "because we right-case the generated commandline options to lowercase"))
     else getContent(in).flatMap(csv => {
@@ -65,8 +65,8 @@ object CSV {
       if (missingHeaders.nonEmpty)
         Failure(new Exception(s"Missing columns: ${missingHeaders.mkString(", ")}"))
       else Success((
-        new CSV(csv,requiredHeaders),
-        Some (s"Ignored columns: ${ignoredHeaders.toArray.deep}")
+        new CSV(csv, requiredHeaders),
+        Some(s"Ignored columns: ${ignoredHeaders.toArray.deep}")
         ))
     })
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/CSV.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/CSV.scala
@@ -63,7 +63,7 @@ object CSV {
       val missingHeaders = upperCaseRequiredHeaders.filter(!upperCaseActualHeaders.contains(_))
 
       if (missingHeaders.nonEmpty)
-        Failure(new Exception(s"Missing columns: ${missingHeaders.sorted.mkString(", ")}"))
+        Failure(new Exception(s"Missing columns: ${missingHeaders.mkString(", ")}"))
       else Success((
         new CSV(csv, requiredHeaders),
         Some(s"Ignored columns: ${ignoredHeaders.toArray.deep}")

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/CSV.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/CSV.scala
@@ -63,7 +63,7 @@ object CSV {
       val missingHeaders = upperCaseRequiredHeaders.filter(!upperCaseActualHeaders.contains(_))
 
       if (missingHeaders.nonEmpty)
-        Failure(new Exception(s"Missing columns: ${missingHeaders.mkString(", ")}"))
+        Failure(new Exception(s"Missing columns: ${missingHeaders.sorted.mkString(", ")}"))
       else Success((
         new CSV(csv, requiredHeaders),
         Some(s"Ignored columns: ${ignoredHeaders.toArray.deep}")

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Constants.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Constants.scala
@@ -16,6 +16,6 @@
 package nl.knaw.dans.easy.stage.lib
 
 object Constants {
-  val DATASET_SDO        = "dataset"
+  val DATASET_SDO       = "dataset"
   val ADDITIONAL_LICENSE = "ADDITIONAL_LICENSE"
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Constants.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Constants.scala
@@ -16,6 +16,6 @@
 package nl.knaw.dans.easy.stage.lib
 
 object Constants {
-  val DATASET_SDO       = "dataset"
+  val DATASET_SDO        = "dataset"
   val ADDITIONAL_LICENSE = "ADDITIONAL_LICENSE"
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Fedora.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Fedora.scala
@@ -44,13 +44,11 @@ object Fedora extends Fedora {
   @tailrec
   def findObjects(query: String, acc: Seq[String] = Nil, token: Option[String] = None): Seq[String] = {
     val objectsQuery = FedoraClient.findObjects().maxResults(findObjectsBatchSize).pid().query(query)
-    val objectsResponse = token match {
-      case None =>
-        objectsQuery.execute
-      case Some(t) =>
-        objectsQuery.sessionToken(t).execute
-    }
-    if (objectsResponse.hasNext) findObjects(query, acc ++ objectsResponse.getPids,  Some(objectsResponse.getToken))
-    else acc ++ objectsResponse.getPids
+    val objectsResponse = token.map(t => objectsQuery.sessionToken(t).execute).getOrElse(objectsQuery.execute)
+
+    if (objectsResponse.hasNext)
+      findObjects(query, acc ++ objectsResponse.getPids, Some(objectsResponse.getToken))
+    else
+      acc ++ objectsResponse.getPids
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Fedora.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Fedora.scala
@@ -44,11 +44,13 @@ object Fedora extends Fedora {
   @tailrec
   def findObjects(query: String, acc: Seq[String] = Nil, token: Option[String] = None): Seq[String] = {
     val objectsQuery = FedoraClient.findObjects().maxResults(findObjectsBatchSize).pid().query(query)
-    val objectsResponse = token.map(t => objectsQuery.sessionToken(t).execute).getOrElse(objectsQuery.execute)
-
-    if (objectsResponse.hasNext)
-      findObjects(query, acc ++ objectsResponse.getPids, Some(objectsResponse.getToken))
-    else
-      acc ++ objectsResponse.getPids
+    val objectsResponse = token match {
+      case None =>
+        objectsQuery.execute
+      case Some(t) =>
+        objectsQuery.sessionToken(t).execute
+    }
+    if (objectsResponse.hasNext) findObjects(query, acc ++ objectsResponse.getPids,  Some(objectsResponse.getToken))
+    else acc ++ objectsResponse.getPids
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
@@ -36,7 +36,6 @@ object JSON {
     def checkProvided(name: String, v: Option[String]) = if(v.isEmpty) throw new IllegalStateException(s"$name must be provided")
     checkProvided("DOI", s.DOI)
     checkProvided("URN", s.URN)
-    checkProvided("Additional license MIME-type", mimeType)
 
     val datastreams =
       List(

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
@@ -36,7 +36,7 @@ object JSON {
     def checkProvided(name: String, v: Option[String]) = if(v.isEmpty) throw new IllegalStateException(s"$name must be provided")
     checkProvided("DOI", s.DOI)
     checkProvided("URN", s.URN)
-    mimeType.toList.map(_ => checkProvided("Additional license MIME-type", mimeType))
+    checkProvided("Additional license MIME-type", mimeType)
 
     val datastreams =
       List(

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
@@ -19,6 +19,7 @@ import java.net.URL
 
 import nl.knaw.dans.easy.stage.Settings
 import nl.knaw.dans.easy.stage.fileitem.FileItemSettings
+import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
 
@@ -81,13 +82,10 @@ object JSON {
                     mimeType: String,
                     parent: (String,String),
                     subordinate: (String,String))(implicit settings: FileItemSettings): String = {
-    def mendeleyJSON = {
+    def createJSON(dataJSON: JObject) = {
       ("namespace" -> "easy-file") ~
         ("datastreams" -> List(
-          ("dsLocation" -> fileLocation.toString) ~
-            ("dsID" -> "EASY_FILE") ~
-            ("controlGroup" -> "R") ~
-            ("mimeType" -> mimeType),
+          dataJSON,
           ("contentFile" -> "EASY_FILE_METADATA") ~
             ("dsID" -> "EASY_FILE_METADATA") ~
             ("controlGroup" -> "X") ~
@@ -99,22 +97,22 @@ object JSON {
           ("predicate" -> HAS_MODEL) ~ ("object" -> "info:fedora/dans-container-item-v1")))
     }
 
+    def mendeleyJSON = {
+      createJSON(
+        ("dsLocation" -> fileLocation.toString) ~
+          ("dsID" -> "EASY_FILE") ~
+          ("controlGroup" -> "R") ~
+          ("mimeType" -> mimeType)
+      )
+    }
+
     def multiDepositJSON = {
-      ("namespace" -> "easy-file") ~
-        ("datastreams" -> List(
-          ("contentFile" -> "EASY_FILE") ~
-            ("dsID" -> "EASY_FILE") ~
-            ("controlGroup" -> "M") ~
-            ("mimeType" -> mimeType),
-          ("contentFile" -> "EASY_FILE_METADATA") ~
-            ("dsID" -> "EASY_FILE_METADATA") ~
-            ("controlGroup" -> "X") ~
-            ("mimeType" -> "text/xml"))) ~
-        ("relations" -> List(
-          ("predicate" -> IS_MEMBER_OF) ~ parent,
-          ("predicate" -> IS_SUBORDINATE_TO) ~ subordinate,
-          ("predicate" -> HAS_MODEL) ~ ("object" -> "info:fedora/easy-model:EDM1FILE"),
-          ("predicate" -> HAS_MODEL) ~ ("object" -> "info:fedora/dans-container-item-v1")))
+      createJSON(
+        ("contentFile" -> "EASY_FILE") ~
+          ("dsID" -> "EASY_FILE") ~
+          ("controlGroup" -> "M") ~
+          ("mimeType" -> mimeType)
+      )
     }
 
     val json = settings.isMendeley

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/JSON.scala
@@ -36,7 +36,7 @@ object JSON {
     def checkProvided(name: String, v: Option[String]) = if(v.isEmpty) throw new IllegalStateException(s"$name must be provided")
     checkProvided("DOI", s.DOI)
     checkProvided("URN", s.URN)
-    checkProvided("Additional license MIME-type", mimeType)
+    mimeType.toList.map(_ => checkProvided("Additional license MIME-type", mimeType))
 
     val datastreams =
       List(

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
@@ -54,6 +54,10 @@ object Util {
   def writeFileMetadata(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EASY_FILE_METADATA"), content)
 
+  def copyFile(sdoDir: File, file: File): Try[Unit] = Try {
+    FileUtils.copyFile(file, new File(sdoDir, "EASY_FILE"))
+  }
+
   def writeItemContainerMetadata(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EASY_ITEM_CONTAINER_MD"), content)
 

--- a/src/test/resources/example.csv
+++ b/src/test/resources/example.csv
@@ -1,4 +1,4 @@
-comment,DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID,IS-MENDELEY
+comment,DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID,FILE-LOCATION,IS-MENDELEY
 
 Sample input for an integration test assuming a dataset submitted by an ordinary user (read: not an archivist)
 Beware for a plain comma in comment. After all it is a comma separated file.

--- a/src/test/resources/example.csv
+++ b/src/test/resources/example.csv
@@ -1,4 +1,4 @@
-comment,DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID
+comment,DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID,IS-MENDELEY
 
 Sample input for an integration test assuming a dataset submitted by an ordinary user (read: not an archivist)
 Beware for a plain comma in comment. After all it is a comma separated file.

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/EASY_ITEM_CONTAINER_MD
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/EASY_ITEM_CONTAINER_MD
@@ -1,0 +1,3 @@
+<icmd:item-container-md version="0.1" xmlns:icmd="http://easy.dans.knaw.nl/easy/item-container-md/">
+  <path>original/newSub</path><name>newSub</name>
+</icmd:item-container-md>

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/cfg.json
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/cfg.json
@@ -1,0 +1,22 @@
+{
+  "namespace":"easy-folder",
+  "datastreams":[{
+    "contentFile":"EASY_ITEM_CONTAINER_MD",
+    "dsID":"EASY_ITEM_CONTAINER_MD",
+    "mimeType":"text/xml",
+    "controlGroup":"X"
+  }],
+  "relations":[{
+    "object":"info:fedora/easy-folder:1",
+    "predicate":"http://dans.knaw.nl/ontologies/relations#isMemberOf"
+  },{
+    "predicate":"info:fedora/fedora-system:def/model#hasModel",
+    "object":"info:fedora/easy-model:EDM1FOLDER"
+  },{
+    "predicate":"http://dans.knaw.nl/ontologies/relations#isSubordinateTo",
+    "object":"info:fedora/easy-dataset:1"
+  },{
+    "predicate":"info:fedora/fedora-system:def/model#hasModel",
+    "object":"info:fedora/dans-container-item-v1"
+  }]
+}

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/fo.xml
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/fo.xml
@@ -1,0 +1,25 @@
+<foxml:digitalObject VERSION="1.1"
+                     xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:foxml="info:fedora/fedora-system:def/foxml#">
+    <foxml:objectProperties>
+        <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+        <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="original/newSub"/>
+        <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId"
+                        VALUE="{{ easy_stage_dataset_owner }}"/>
+    </foxml:objectProperties>
+    <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+        <foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record" MIMETYPE="text/xml"
+                                 FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/">
+            <foxml:xmlContent>
+                <oai_dc:dc
+                        xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns="">
+                    <dc:title>original/newSub</dc:title>
+                </oai_dc:dc>
+            </foxml:xmlContent>
+        </foxml:datastreamVersion>
+    </foxml:datastream>
+</foxml:digitalObject>

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/EASY_FILE_METADATA
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/EASY_FILE_METADATA
@@ -1,0 +1,9 @@
+<fimd:file-item-md version="0.1" xmlns:fimd="http://easy.dans.knaw.nl/easy/file-item-md/">
+        <name>file.mpeg</name>
+        <path>original/newSub/file.mpeg</path>
+        <mimeType>video/mpeg</mimeType>
+        <size>1</size>
+        <creatorRole>DEPOSITOR</creatorRole>
+        <visibleTo>ANONYMOUS</visibleTo>
+        <accessibleTo>NONE</accessibleTo>
+      </fimd:file-item-md>

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/cfg.json
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/cfg.json
@@ -1,9 +1,9 @@
 {
   "namespace":"easy-file",
   "datastreams":[{
-    "dsLocation":"http://x.nl/l/d",
+    "contentFile":"EASY_FILE",
     "dsID":"EASY_FILE",
-    "controlGroup":"R",
+    "controlGroup":"M",
     "mimeType":"video/mpeg"
   },{
     "contentFile":"EASY_FILE_METADATA",

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/fo.xml
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/fo.xml
@@ -1,0 +1,26 @@
+<foxml:digitalObject VERSION="1.1"
+                     xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:foxml="info:fedora/fedora-system:def/foxml#">
+    <foxml:objectProperties>
+        <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="file.mpeg"/>
+        <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+        <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId"
+                        VALUE="{{ easy_stage_dataset_owner }}"/>
+    </foxml:objectProperties>
+    <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+        <foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record" MIMETYPE="text/xml"
+                                 FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/">
+            <foxml:xmlContent>
+                <oai_dc:dc
+                        xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns="">
+                    <dc:type>video/mpeg</dc:type>
+                    <dc:title>file.mpeg</dc:title>
+                </oai_dc:dc>
+            </foxml:xmlContent>
+        </foxml:datastreamVersion>
+    </foxml:datastream>
+</foxml:digitalObject>

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -68,6 +68,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       sdoSetDir = Some(new File("target/testSDO")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = Some(1),
+      isMendeley = Some(true),
       datasetId = Some("easy-dataset:1"),
       pathInDataset = Some(new File("original/newSub/file.mpeg")),
       format = Some("video/mpeg"),
@@ -115,6 +116,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       sdoSetDir = Some(new File("target/testSDO")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = None,
+      isMendeley = Some(true),
       datasetId = Some("easy-dataset:1"),
       pathInDataset = Some(new File("original/newSub/file.mpeg")),
       format = None,
@@ -135,6 +137,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       sdoSetDir = Some(new File("target/testSDO")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = Some(1),
+      isMendeley = Some(true),
       datasetId = Some("easy-dataset:1"),
       pathInDataset = Some(new File("original/newSub/file.mpeg")),
       format = Some("video/mpeg"),
@@ -153,6 +156,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       sdoSetDir = Some(new File("target/testSDO")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = Some(1),
+      isMendeley = Some(true),
       datasetId = Some("easy-dataset:1"),
       pathInDataset = Some(new File("original/newSub/file.mpeg")),
       format = Some("video/mpeg"),
@@ -175,6 +179,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       ownerId = "testOwner",
       pathInDataset = new File("path/to/uuid-as-file-name"),
       size = Some(1),
+      isMendeley = Some(true),
       format = Some("text/plain"),
       title = Some("A nice title"))
     EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> "ficticiousParentSdo")
@@ -195,6 +200,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       ownerId = "testOwner",
       pathInDataset = new File("path/to/uuid-as-file-name"),
       size = Some(1),
+      isMendeley = Some(true),
       format = Some("text/plain"),
       title = None)
     EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> "ficticiousParentSdo")

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -66,6 +66,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
   "run" should "create expected file item SDOs in the mendeley use case" in {
     EasyStageFileItem.run(new FileItemSettings(
       sdoSetDir = Some(new File("target/testSDO")),
+      file = Some(new File("original/newSub/file.mpeg")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = Some(1),
       isMendeley = Some(true),
@@ -114,6 +115,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
   it should "create expected file item SDOs in the multi-deposit use case" in {
     EasyStageFileItem.run(new FileItemSettings(
       sdoSetDir = Some(new File("target/testSDO")),
+      file = Some(new File("original/newSub/file.mpeg")), // TODO this may fail!
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = Some(1),
       isMendeley = Some(false),
@@ -162,6 +164,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
   it should "report a missing size" in {
     the[NoSuchElementException] thrownBy EasyStageFileItem.run(new FileItemSettings(
       sdoSetDir = Some(new File("target/testSDO")),
+      file = Some(new File("original/newSub/file.mpeg")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = None,
       isMendeley = Some(true),
@@ -183,6 +186,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
   it should "report a fedora error" in {
     the[Exception] thrownBy EasyStageFileItem.run(new FileItemSettings(
       sdoSetDir = Some(new File("target/testSDO")),
+      file = Some(new File("original/newSub/file.mpeg")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = Some(1),
       isMendeley = Some(true),
@@ -202,6 +206,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
   it should "report the dataset does not exist" in {
     the[Exception] thrownBy EasyStageFileItem.run(new FileItemSettings(
       sdoSetDir = Some(new File("target/testSDO")),
+      file = Some(new File("original/newSub/file.mpeg")),
       datastreamLocation = Some(new URL("http://x.nl/l/d")),
       size = Some(1),
       isMendeley = Some(true),
@@ -224,6 +229,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
     sdoSetDir.mkdirs()
     implicit val s = FileItemSettings(
       sdoSetDir = sdoSetDir,
+      file = new File("path/to/uuid-as-file-name"),
       ownerId = "testOwner",
       pathInDataset = new File("path/to/uuid-as-file-name"),
       size = Some(1),
@@ -245,6 +251,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
     sdoSetDir.mkdirs()
     implicit val s = FileItemSettings(
       sdoSetDir = sdoSetDir,
+      file = new File("path/to/uuid-as-file-name"),
       ownerId = "testOwner",
       pathInDataset = new File("path/to/uuid-as-file-name"),
       size = Some(1),

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.stage.lib
 
-import java.io.{ByteArrayInputStream, FileInputStream}
+import java.io.ByteArrayInputStream
 
 import nl.knaw.dans.easy.stage.fileitem.FileItemConf
 import org.scalatest.{FlatSpec, Matchers}
@@ -29,7 +29,7 @@ class CsvSpec extends FlatSpec with Matchers {
       "FORMAT,DATASET-ID,xxx,STAGED-DIGITAL-OBJECT-SET"
         .stripMargin.getBytes)
     the[Exception] thrownBy CSV(in, conf.longOptionNames).get should
-      have message "Missing columns: PATH-IN-DATASET, DATASTREAM-LOCATION, SIZE, FILE-LOCATION, IS-MENDELEY, ACCESSIBLE-TO, VISIBLE-TO, CREATOR-ROLE, OWNER-ID"
+      have message "Missing columns: ACCESSIBLE-TO, CREATOR-ROLE, DATASTREAM-LOCATION, FILE-LOCATION, IS-MENDELEY, OWNER-ID, PATH-IN-DATASET, SIZE, VISIBLE-TO"
   }
 
   it should "fail with uppercase in any of the required headers" in {

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
@@ -29,7 +29,7 @@ class CsvSpec extends FlatSpec with Matchers {
       "FORMAT,DATASET-ID,xxx,STAGED-DIGITAL-OBJECT-SET"
         .stripMargin.getBytes)
     the[Exception] thrownBy CSV(in, conf.longOptionNames).get should
-      have message "Missing columns: PATH-IN-DATASET, DATASTREAM-LOCATION, SIZE, ACCESSIBLE-TO, VISIBLE-TO, CREATOR-ROLE, OWNER-ID"
+      have message "Missing columns: PATH-IN-DATASET, DATASTREAM-LOCATION, SIZE, IS-MENDELEY, ACCESSIBLE-TO, VISIBLE-TO, CREATOR-ROLE, OWNER-ID"
   }
 
   it should "fail with uppercase in any of the required headers" in {

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.stage.lib
 
-import java.io.ByteArrayInputStream
+import java.io.{ByteArrayInputStream, FileInputStream}
 
 import nl.knaw.dans.easy.stage.fileitem.FileItemConf
 import org.scalatest.{FlatSpec, Matchers}
@@ -29,7 +29,7 @@ class CsvSpec extends FlatSpec with Matchers {
       "FORMAT,DATASET-ID,xxx,STAGED-DIGITAL-OBJECT-SET"
         .stripMargin.getBytes)
     the[Exception] thrownBy CSV(in, conf.longOptionNames).get should
-      have message "Missing columns: ACCESSIBLE-TO, CREATOR-ROLE, DATASTREAM-LOCATION, FILE-LOCATION, IS-MENDELEY, OWNER-ID, PATH-IN-DATASET, SIZE, VISIBLE-TO"
+      have message "Missing columns: PATH-IN-DATASET, DATASTREAM-LOCATION, SIZE, FILE-LOCATION, IS-MENDELEY, ACCESSIBLE-TO, VISIBLE-TO, CREATOR-ROLE, OWNER-ID"
   }
 
   it should "fail with uppercase in any of the required headers" in {

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/CsvSpec.scala
@@ -29,7 +29,7 @@ class CsvSpec extends FlatSpec with Matchers {
       "FORMAT,DATASET-ID,xxx,STAGED-DIGITAL-OBJECT-SET"
         .stripMargin.getBytes)
     the[Exception] thrownBy CSV(in, conf.longOptionNames).get should
-      have message "Missing columns: PATH-IN-DATASET, DATASTREAM-LOCATION, SIZE, IS-MENDELEY, ACCESSIBLE-TO, VISIBLE-TO, CREATOR-ROLE, OWNER-ID"
+      have message "Missing columns: PATH-IN-DATASET, DATASTREAM-LOCATION, SIZE, FILE-LOCATION, IS-MENDELEY, ACCESSIBLE-TO, VISIBLE-TO, CREATOR-ROLE, OWNER-ID"
   }
 
   it should "fail with uppercase in any of the required headers" in {


### PR DESCRIPTION
Stage-Dataset can now stage non-Mendeley deposits. In order to make this work, I had to add a couple of extra arguments to the parameter list of both `stage-dataset` and `stage-file-item`. The main difference between a Mendeley and non-Mendeley execution can be found in `JSON.scala` (generating another JSON content), as well as `EasyStageFileItem.scala` (copying files to the staged folder).

Notice that this PR is mutually dependant with [pull request 36 in easy-ingest-flow](https://github.com/DANS-KNAW/easy-ingest-flow/pull/36)

@DANS-KNAW/easy please review!
