### PR TITLE
Fix tests

### DIFF
--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -18,7 +18,6 @@ package nl.knaw.dans.easy.stage
 import java.io.File
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
-import nl.knaw.dans.easy.Util._
 import nl.knaw.dans.easy.stage.EasyStageDataset._
 import nl.knaw.dans.easy.stage.lib.Constants.DATASET_SDO
 import org.apache.commons.io.FileUtils

--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.stage
 import java.io.File
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
+import nl.knaw.dans.easy.Util._
 import nl.knaw.dans.easy.stage.EasyStageDataset._
 import nl.knaw.dans.easy.stage.lib.Constants.DATASET_SDO
 import org.apache.commons.io.FileUtils
@@ -96,6 +97,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
   }
 
   "run" should "create SDO sets from test bags (proof the puddings by eating them with easy-ingest)" in {
+    assume(canConnect(xsds))
 
     createProps()
 

--- a/src/test/scala/nl/knaw/dans/easy/stage/Util.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/Util.scala
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy
+
+import java.net.{HttpURLConnection, URL}
+
+import scala.util.Try
+
+package object Util {
+
+  val xsds = Array("https://easy.dans.knaw.nl/schemas/md/2016/ddm.xsd",
+    "http://dublincore.org/schemas/xmls/qdc/dc.xsd")
+
+  def canConnect(urls: Array[String]): Boolean = Try {
+    urls.map { url =>
+      new URL(url).openConnection match {
+        case connection: HttpURLConnection =>
+          connection.connect()
+          connection.disconnect()
+          true
+        case _ => throw new Exception
+      }
+    }
+  }.isSuccess
+
+}

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileAccesRightsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileAccesRightsSpec.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.stage.fileitem
 import nl.knaw.dans.common.lang.dataset.AccessCategory
 import org.scalatest.{FlatSpec, Matchers}
 
-class UserCategorySpec extends FlatSpec with Matchers {
+class FileAccesRightsSpec extends FlatSpec with Matchers {
   /*
   according to ddm.xsd there are 5 options for the dataset AccessRights
         <xs:enumeration value="OPEN_ACCESS">

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/EmdSpec.scala
@@ -17,15 +17,14 @@ package nl.knaw.dans.easy.stage.lib
 
 import java.io.File
 
-import nl.knaw.dans.easy.stage.Settings
 import nl.knaw.dans.easy.Util._
+import nl.knaw.dans.easy.stage.Settings
 import nl.knaw.dans.easy.stage.dataset.EMD
 import nl.knaw.dans.pf.language.ddm.api.Ddm2EmdCrosswalk
-import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FileUtils.{deleteDirectory, deleteQuietly, write}
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Success
 
 class EmdSpec extends FlatSpec with Matchers {
 

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/EmdSpec.scala
@@ -17,10 +17,8 @@ package nl.knaw.dans.easy.stage.lib
 
 import java.io.File
 
-import nl.knaw.dans.easy.Util._
-import nl.knaw.dans.easy.stage.Settings
+import nl.knaw.dans.easy.stage._
 import nl.knaw.dans.easy.stage.dataset.EMD
-import nl.knaw.dans.pf.language.ddm.api.Ddm2EmdCrosswalk
 import org.apache.commons.io.FileUtils.{deleteDirectory, deleteQuietly, write}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -29,7 +27,7 @@ import scala.util.Success
 class EmdSpec extends FlatSpec with Matchers {
 
   val sdoSetDir = new File("target/test/EmdSpec/sdoSet")
-  def newSettings(bagitDir: File, crosswalker: Ddm2EmdCrosswalk = new Ddm2EmdCrosswalk(null)): Settings = {
+  def newSettings(bagitDir: File): Settings = {
     new Settings(ownerId = "", bagitDir = bagitDir, sdoSetDir = sdoSetDir, isMendeley = false, disciplines = Map[String, String]())
   }
 
@@ -48,8 +46,7 @@ class EmdSpec extends FlatSpec with Matchers {
   it should "produce an error containing possible values" in {
     assume(canConnect(xsds))
 
-    val ddm = <ddm:DDM xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
-                       xmlns:dc="http://purl.org/dc/elements/1.1/"
+    val ddm = <ddm:DDM xmlns:dc="http://purl.org/dc/elements/1.1/"
                        xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <ddm:profile>
@@ -67,7 +64,7 @@ class EmdSpec extends FlatSpec with Matchers {
 
     EMD.create(sdoSetDir).failed.get.getMessage should
       include("[OPEN_ACCESS, OPEN_ACCESS_FOR_REGISTERED_USERS, GROUP_ACCESS, REQUEST_PERMISSION, NO_ACCESS]")
-    sdoSetDir.list() shouldBe Array()
+    sdoSetDir.list() shouldBe null
 
     deleteQuietly(tmpDDM)
     deleteDirectory(sdoSetDir)

--- a/src/test/scala/nl/knaw/dans/easy/stage/package.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/package.scala
@@ -17,12 +17,13 @@ package nl.knaw.dans.easy
 
 import java.net.{HttpURLConnection, URL}
 
+import nl.knaw.dans.pf.language.ddm.handlermaps.NameSpace
+import nl.knaw.dans.pf.language.emd.types.EmdConstants
+
 import scala.util.Try
 
-package object Util {
-
-  val xsds = Array("https://easy.dans.knaw.nl/schemas/md/2016/ddm.xsd",
-    "http://dublincore.org/schemas/xmls/qdc/dc.xsd")
+package object stage {
+  val xsds: Array[String] = Array(NameSpace.DC.uri, NameSpace.DDM.uri)
 
   def canConnect(urls: Array[String]): Boolean = Try {
     urls.map { url =>


### PR DESCRIPTION
fixes builds that occasionally fail
#### When applied it will
- ignore test when required XSDs are (temporarily) not available
#### Where should the reviewer @DANS-KNAW/easy start?
- `assume(canConnect(xsds))` in EmdSpec is the core of the change
- `for {bag <- ...` in EmdSpec looped over nothing in the past
- settings no longer requires a fedora connection, so we can test proper creation of the EMD file, not just of its content
- UserCategory was renamed to FileAccesRights in the past, but the corresponding test wasn't
#### How should this be manually tested?
- run `mvn clean install`
- without a network connection some test will be <strike>ignored</strike> cancelled
- with  a network connection all test will succeed
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy- | [PR#](PRlink) |
