### PR TITLE
Added connect and read time-outs of 1 second each. Hopefully, this wi…

### DIFF
--- a/src/test/scala/nl/knaw/dans/easy/stage/package.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/package.scala
@@ -29,6 +29,8 @@ package object stage {
     urls.map { url =>
       new URL(url).openConnection match {
         case connection: HttpURLConnection =>
+          connection.setConnectTimeout(1000)
+          connection.setReadTimeout(1000)
           connection.connect()
           connection.disconnect()
           true


### PR DESCRIPTION
Follow-up on #86 
#### When applied it will
- Make sure that unit test dependencies on unresponsive or slow hosts will not slow down the build too much.
#### Where should the reviewer @DANS-KNAW/easy start?

See the only changed file
#### How should this be manually tested?

Hard to simulate a slow host. May not be worth your while
#### related pull requests on github

| repo | PR |
| --- | --- |
| `easy-stage-dataset` | #86 |

…ll prevent the build from becoming very slow due to unit test dependencies on unresponsive hosts
