### PR TITLE
NO JIRA ISSUE: Removed ownerId from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ SYNOPSIS
                           <EASY-bag> <staged-digital-object-set>
 
     easy-stage-file-item [<options>...] <staged-digital-object-set>
-    easy-stage-file-item <staged-digital-object-set> <csv-file>
 
 
 DESCRIPTION

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,4 +1,3 @@
-owner={{ easy_stage_dataset_owner }}
 fcrepo.url={{ easy_stage_dataset_fcrepo_service_url }}
 fcrepo.user={{ easy_stage_dataset_fcrepo_user }}
 fcrepo.password={{ easy_stage_dataset_fcrepo_password }}

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItem.scala
@@ -118,7 +118,7 @@ object EasyStageFileItem {
       cfgContent   <- Try { JSON.createFileCfg(s.datastreamLocation.getOrElse(s.unsetUrl), mime, parent, s.subordinate) }
       _            <- writeJsonCfg(sdoDir, cfgContent)
       title        <- Try {s.title.getOrElse(s.pathInDataset.get.getName)}
-      foxmlContent  = getFileFOXML(title, s.ownerId, mime)
+      foxmlContent  = getFileFOXML(title, s.ownerId.get, mime)
       _            <- writeFoxml(sdoDir, foxmlContent)
       fmd          <- EasyFileMetadata(s)
       _            <- writeFileMetadata(sdoDir, fmd)
@@ -131,7 +131,7 @@ object EasyStageFileItem {
     sdoDir.mkdir()
     for {
       _ <- writeJsonCfg(sdoDir,JSON.createDirCfg(parent, s.subordinate))
-      _ <- writeFoxml(sdoDir, getDirFOXML(path, s.ownerId))
+      _ <- writeFoxml(sdoDir, getDirFOXML(path, s.ownerId.get))
       _ <- writeItemContainerMetadata(sdoDir,EasyItemContainerMd(path))
     } yield ()
   }

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemConf.scala
@@ -38,7 +38,6 @@ class FileItemConf(args: Seq[String]) extends ScallopConf(args) {
             |Usage:
             |
             | $printedName [<options>...] <staged-digital-object-set>
-            | $printedName <staged-digital-object-set> <csv-file>
             |
             |Options:
             |""".stripMargin)

--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileItemSettings.scala
@@ -29,7 +29,7 @@ case class FileItemSettings (sdoSetDir: Option[File],
                              datastreamLocation: Option[URL] = None,
                              unsetUrl: URL = new URL(props.getString("redirect-unset-url")),
                              size: Option[Long] = None,
-                             ownerId: String = props.getString("owner"),
+                             ownerId: Option[String] = None,
                              pathInDataset: Option[File],
                              title:  Option[String] = None,
                              format: Option[String] = None,
@@ -70,7 +70,7 @@ object FileItemSettings {
       file = Some(file),
       datasetId = None,
       size = size,
-      ownerId = ownerId,
+      ownerId = Some(ownerId),
       pathInDataset = Some(pathInDataset),
       format = format,
       sha1 = sha1,
@@ -88,7 +88,7 @@ object FileItemSettings {
     new FileItemSettings(
       sdoSetDir = Some(sdoSetDir),
       datasetId = None,
-      ownerId = ownerId,
+      ownerId = Some(ownerId),
       pathInDataset = Some(pathInDataset)
     )
 
@@ -103,7 +103,7 @@ object FileItemSettings {
       accessibleTo = conf.accessibleTo(),
       visibleTo = conf.visibleTo(),
       creatorRole = conf.creatorRole(),
-      ownerId = conf.ownerId.get.map(_.trim).filter(_.nonEmpty).getOrElse(props.getString("owner")),
+      ownerId = conf.ownerId.get.map(_.trim).filter(_.nonEmpty),
       datasetId = conf.datasetId.get,
       pathInDataset = conf.pathInDataset.get,
       format = conf.format.get,

--- a/src/test/resources/expectedFileItemSDOs/newSub/fo.xml
+++ b/src/test/resources/expectedFileItemSDOs/newSub/fo.xml
@@ -6,7 +6,7 @@
         <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="original/newSub"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId"
-                        VALUE="{{ easy_stage_dataset_owner }}"/>
+                        VALUE="testOwner"/>
     </foxml:objectProperties>
     <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
         <foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record" MIMETYPE="text/xml"

--- a/src/test/resources/expectedFileItemSDOs/newSub_file_mpeg/fo.xml
+++ b/src/test/resources/expectedFileItemSDOs/newSub_file_mpeg/fo.xml
@@ -6,7 +6,7 @@
         <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="file.mpeg"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId"
-                        VALUE="{{ easy_stage_dataset_owner }}"/>
+                        VALUE="testOwner"/>
     </foxml:objectProperties>
     <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
         <foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record" MIMETYPE="text/xml"

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/fo.xml
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub/fo.xml
@@ -6,7 +6,7 @@
         <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="original/newSub"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId"
-                        VALUE="{{ easy_stage_dataset_owner }}"/>
+                        VALUE="testOwner"/>
     </foxml:objectProperties>
     <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
         <foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record" MIMETYPE="text/xml"

--- a/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/fo.xml
+++ b/src/test/resources/expectedFileItemSDOsWithMultiDeposit/newSub_file_mpeg/fo.xml
@@ -6,7 +6,7 @@
         <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="file.mpeg"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
         <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId"
-                        VALUE="{{ easy_stage_dataset_owner }}"/>
+                        VALUE="testOwner"/>
     </foxml:objectProperties>
     <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
         <foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record" MIMETYPE="text/xml"

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -65,6 +65,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
 
   "run" should "create expected file item SDOs with 'unset' url when neither file-location nor datastream-location provided" in {
     EasyStageFileItem.run(new FileItemSettings(
+      ownerId = Some("testOwner"),
       sdoSetDir = Some(new File("target/testSDO")),
       size = Some(1),
       datasetId = Some("easy-dataset:1"),
@@ -104,7 +105,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       "dc_title" -> "original/newSub",
       "prop_state" -> "Active",
       "prop_label" -> "original/newSub",
-      "prop_ownerId" -> "{{ easy_stage_dataset_owner }}")
+      "prop_ownerId" -> "testOwner")
 
     // clean up
 
@@ -113,6 +114,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
 
   it should "create expected file item SDOs in the multi-deposit use case (i.e. when file-location is provided)" in {
     EasyStageFileItem.run(new FileItemSettings(
+      ownerId = Some("testOwner"),
       sdoSetDir = Some(new File("target/testSDO")),
       file = Some(new File("original/newSub/file.mpeg")), // TODO this may fail!
       size = Some(1),
@@ -153,7 +155,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       "dc_title" -> "original/newSub",
       "prop_state" -> "Active",
       "prop_label" -> "original/newSub",
-      "prop_ownerId" -> "{{ easy_stage_dataset_owner }}")
+      "prop_ownerId" -> "testOwner")
 
     // clean up
 


### PR DESCRIPTION
NO JIRA ISSUE: Removed ownerId from config file
#### When applied it will
- Remove ownerId setting from `application.properties`
#### Where should the reviewer @DANS-KNAW/easy start?

The [template config file](https://github.com/DANS-KNAW/easy-stage-dataset/pull/91/files#diff-bdcf2a6b4cc6822f745e417c6e52fb4eL1)
#### How should this be manually tested?

Try to stage a dataset or file from the command line
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy-dtap | [PR#31](https://github.com/DANS-KNAW/easy-dtap/pull/31) |
