### PR TITLE
Scala lib collectResults refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.32</version>
+        <version>1.33</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-stage-dataset</artifactId>
@@ -101,7 +101,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib</artifactId>
-            <version>1.x-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
         </dependency>
+        <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-scala-lib</artifactId>
+            <version>1.x-SNAPSHOT</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -31,6 +31,7 @@ import nl.knaw.dans.pf.language.emd.EasyMetadata
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils.readFileToString
 import org.slf4j.LoggerFactory
+import nl.knaw.dans.lib.error._
 
 import scala.util.{Failure, Success, Try}
 
@@ -101,7 +102,7 @@ object EasyStageDataset {
           createFolderSdo(child, parentSDO).flatMap(_ => createFileAndFolderSdos(child, getSDODir(child).getName))
         else
           Failure(new RuntimeException(s"Unknown object encountered while traversing ${dir.getName}: ${child.getName}"))
-      Try { dir.listFiles().toList }.flatMap(_.map(visit).allSuccess)
+      Try { dir.listFiles().toList }.flatMap(_.map(visit).collectResults.map(_ => ()))
     }
 
     def createFileSdo(file: File, parentSDO: String): Try[Unit] = {

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -19,7 +19,7 @@ import java.io.File
 
 import nl.knaw.dans.easy.stage.Settings
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 import scala.xml.{Elem, XML}
 
 object Util {
@@ -36,14 +36,6 @@ object Util {
       }
     }
     else "<Unknown error location>"
-  }
-
-  implicit class TryExtensions(xs: Seq[Try[Unit]]) {
-    def allSuccess: Try[Unit] =
-      if (xs.exists(_.isFailure))
-        Failure(new CompositeException(xs.collect { case Failure(e) => e }))
-      else
-        Success(Unit)
   }
 
   def readMimeType(filePath: String)(implicit s: Settings): Try[String] = Try {


### PR DESCRIPTION
@DANS-KNAW/easy 
- adds _dans-scala-lib_ as a dependency
- refactors the use of `sequence` or `collectResults` to use the library implementation
