### PR TITLE
1128 UTF8

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.stage
 
 import java.io.{File, FileNotFoundException}
-import java.net.{URI, URL, URLEncoder}
+import java.net.{URL, URLEncoder}
 import java.nio.file.{Path, Paths}
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory
@@ -28,17 +28,17 @@ import nl.knaw.dans.easy.stage.lib.Constants._
 import nl.knaw.dans.easy.stage.lib.FOXML._
 import nl.knaw.dans.easy.stage.lib.JSON
 import nl.knaw.dans.easy.stage.lib.Util._
+import nl.knaw.dans.lib.error._
 import nl.knaw.dans.pf.language.emd.EasyMetadata
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils.readFileToString
-import org.slf4j.LoggerFactory
-import nl.knaw.dans.lib.error._
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 object EasyStageDataset {
-  val log = LoggerFactory.getLogger(getClass)
+  val log: Logger = LoggerFactory.getLogger(getClass)
 
   def main(args: Array[String]) {
     val props = new PropertiesConfiguration(new File(System.getProperty("app.home"), "cfg/application.properties"))
@@ -86,7 +86,7 @@ object EasyStageDataset {
   def createFileAndFolderSdos(dir: File, parentSDO: String, rights: AccessCategory)(implicit s: Settings): Try[Unit] = {
     val maybeSha1Map: Try[Map[String, String]] = Try {
       val sha1File = "manifest-sha1.txt"
-      readFileToString(new File(s.bagitDir, sha1File))
+      readFileToString(new File(s.bagitDir, sha1File),"UTF-8")
         .lines.filter(_.nonEmpty)
         .map(_.split("\\h+", 2)) // split into tokens on sequences of horizontal white space characters
         .map {
@@ -110,7 +110,7 @@ object EasyStageDataset {
     def createFileSdo(file: File, parentSDO: String): Try[Unit] = {
       log.debug(s"Creating file SDO for $file")
       val datasetRelativePath = getDatasetRelativePath(file)
-      val urlEncodedDatasetRelativePath = Paths.get("", datasetRelativePath.asScala.map {case p => URLEncoder.encode(p.toString, "UTF-8") }.toArray :_*)
+      val urlEncodedDatasetRelativePath = Paths.get("", datasetRelativePath.asScala.map {p => URLEncoder.encode(p.toString, "UTF-8") }.toArray :_*)
       for {
         sdoDir <- mkdirSafe(getSDODir(file))
         bagRelativePath = s.bagitDir.toPath.relativize(file.toPath).toString

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -18,10 +18,11 @@ package nl.knaw.dans.easy.stage.dataset
 import java.io.File
 
 import nl.knaw.dans.easy.stage.Settings
+import nl.knaw.dans.easy.stage.lib.Util.loadXML
 
 import scala.sys.error
 import scala.util.Try
-import scala.xml.{Elem, XML}
+import scala.xml.Elem
 
 object Util {
 
@@ -41,36 +42,36 @@ object Util {
 
   def readMimeType(filePath: String)(implicit s: Settings): Try[String] = Try {
     val mimes = for {
-      file <- loadXML("metadata/files.xml") \\ "files" \ "file"
+      file <- loadBagXML("metadata/files.xml") \\ "files" \ "file"
       if (file \ "@filepath").text == filePath
       mime <- file \ "format"
     } yield mime
     if (mimes.size != 1)
       throw new scala.RuntimeException(s"Filepath [$filePath] doesn't exist in files.xml, or isn't unique.")
-    mimes(0).text
+    mimes.head.text
   }
 
   def readTitle(filePath: String)(implicit s: Settings): Try[Option[String]] = Try {
     val titles = for {
-      file <- loadXML("metadata/files.xml") \\ "files" \ "file"
+      file <- loadBagXML("metadata/files.xml") \\ "files" \ "file"
       if (file \ "@filepath").text == filePath
       title <- file \ "title"
     } yield title
-    if(titles.size == 1) Option(titles(0).text)
+    if(titles.size == 1) Option(titles.head.text)
     else None
   }
 
   def readAudiences()(implicit s: Settings): Try[Seq[String]] = Try {
     for {
-      audience <- loadXML("metadata/dataset.xml") \\ "DDM" \ "profile" \ "audience"
+      audience <- loadBagXML("metadata/dataset.xml") \\ "DDM" \ "profile" \ "audience"
     } yield audience.text
   }
 
-  private def loadXML(fileName: String)(implicit s: Settings): Elem = {
+  def loadBagXML(fileName: String)(implicit s: Settings): Elem = {
     val metadataFile = new File(s.bagitDir, fileName)
     if (!metadataFile.exists) {
       error(s"Unable to find `$fileName` in bag.")
     }
-    XML.loadFile(metadataFile)
+    loadXML(metadataFile)
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/Util.scala
@@ -15,15 +15,19 @@
  */
 package nl.knaw.dans.easy.stage.lib
 
-import java.io.File
+import java.io.{File, FileInputStream, InputStreamReader}
 
 import org.apache.commons.io.FileUtils
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.{Failure, Try}
+import scala.xml.{Elem, XML}
 
 object Util {
-  val log = LoggerFactory.getLogger(getClass)
+  val log: Logger = LoggerFactory.getLogger(getClass)
+
+  def loadXML(metadataFile: File): Elem =
+    XML.load(new InputStreamReader(new FileInputStream(metadataFile), "UTF-8"))
 
   def writeToFile(f: File, s: String): Try[Unit] =
     /*

--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -132,12 +132,14 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
     // a bag with one folder with three files also result in five SDO's
     new File(puddingsDir,"one-invalid-sha1").listFiles().length shouldBe 5
 
+    FileUtils.readFileToString(new File ("target/sdoPuddings/one-invalid-sha1/dataset/EMD"),"UTF-8") should include ("planetoïde")
+
     // cleanup, leave created SDO sets as puddings to proof by eating them
     emptyDataDir.delete()
     tmpProps.delete()
   }
 
-  def createProps() = FileUtils.write(tmpProps, "owner=dsowner\nredirect-unset-url=http://unset.dans.knaw.nl")
+  def createProps(): Unit = FileUtils.write(tmpProps, "owner=dsowner\nredirect-unset-url=http://unset.dans.knaw.nl")
 
   def createSettings(bagitDir: File, sdoSetDir: File): Settings = {
     // the user and disciplines should exist in deasy

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -21,12 +21,12 @@ import java.net.URL
 import nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem._
 import nl.knaw.dans.easy.stage.fileitem.SdoFiles._
 import nl.knaw.dans.easy.stage.lib.Fedora
+import nl.knaw.dans.easy.stage.lib.Util.loadXML
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.immutable.HashMap
 import scala.reflect.io.Path
 import scala.util.{Failure, Success, Try}
-import scala.xml.XML
 
 class EasyStageFileItemSpec extends FlatSpec with Matchers {
   System.setProperty("app.home", "src/main/assembly/dist")
@@ -241,10 +241,10 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       visibleTo = FileAccessRights.ANONYMOUS)
     EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> "ficticiousParentSdo")
 
-    val efmd =  XML.loadFile(new File(sdoDir, "EASY_FILE_METADATA"))
+    val efmd =  loadXML(new File(sdoDir, "EASY_FILE_METADATA"))
     (efmd \ "name").text shouldBe "A nice title"
     (efmd \ "path").text shouldBe "path/to/A nice title"
-    val foxml = XML.loadFile(new File(sdoDir, "fo.xml"))
+    val foxml = loadXML(new File(sdoDir, "fo.xml"))
     (foxml \ "datastream" \ "datastreamVersion" \ "xmlContent" \ "dc" \ "title").text shouldBe "A nice title"
   }
 
@@ -266,22 +266,22 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers {
       visibleTo = FileAccessRights.ANONYMOUS)
     EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> "ficticiousParentSdo")
 
-    val efmd =  XML.loadFile(new File(sdoDir, "EASY_FILE_METADATA"))
+    val efmd =  loadXML(new File(sdoDir, "EASY_FILE_METADATA"))
     (efmd \ "name").text shouldBe "uuid-as-file-name"
     (efmd \ "path").text shouldBe "path/to/uuid-as-file-name"
-    val foxml = XML.loadFile(new File(sdoDir, "fo.xml"))
+    val foxml = loadXML(new File(sdoDir, "fo.xml"))
     (foxml \ "datastream" \ "datastreamVersion" \ "xmlContent" \ "dc" \ "title").text shouldBe "uuid-as-file-name"
   }
 
   def mockEasyFilesAndFolders(expectations: Map[String,Try[(String,String)]]): EasyFilesAndFolders =
     new EasyFilesAndFolders {
       override def getExistingAncestor(file: File, datasetId: String): Try[(String, String)] =
-        expectations.get(s"$datasetId $file").get
+        expectations(s"$datasetId $file")
     }
 
   def mockFedora(expectations: Map[String,Seq[String]]): Fedora =
     new Fedora {
       override def findObjects(query: String, acc: Seq[String], token: Option[String]): Seq[String] =
-        expectations.get(query).get
+        expectations(query)
     }
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/SdoFiles.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/SdoFiles.scala
@@ -17,11 +17,12 @@ package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
 
-import org.apache.commons.io.FileUtils._
+import org.apache.commons.io.FileUtils.readFileToString
+import nl.knaw.dans.easy.stage.lib.Util.loadXML
 import org.json4s.native._
 
+import scala.io.Source
 import scala.reflect.io.Path
-import scala.xml.XML
 
 /**
   * Gets filenames of and SDO set or essential contents of SDO files
@@ -35,14 +36,14 @@ object SdoFiles {
 
   /** Gets (label,text) of elements in the root of the document */
   def readFlatXml(file: String): Set[(String, String)] =
-    (XML.loadFile(file) \ "_")
+    (loadXML(new File(file)) \ "_")
       .map(n => n.label -> n.text)
       .toSet
 
   /** Gets (label,text) of dc elements and (name,value)-attributes of object properties,
     * labels are prefixed with "dc_" and names are prefixed with "prop_". */
   def readDatastreamFoxml(file: String): Set[(String, String)] = {
-    val xml = XML.loadFile(file)
+    val xml = loadXML(new File(file))
     (xml \\ "dc" \ "_")
       .map(node => "dc_" + node.label -> node.text)
       .toSet ++
@@ -57,7 +58,7 @@ object SdoFiles {
   type S2A = Map[String, Any]
 
   def readCfgJson(file: String): (Option[String], Option[Set[S2S]], Option[Set[S2S]]) = {
-    val content = readFileToString(new File(file))
+    val content = readFileToString(new File(file),"UTF-8")
     val map = parseJson(content).values.asInstanceOf[S2A]
     val namespace = map.get("namespace").map(_.asInstanceOf[String])
     val datastreams = map.get("datastreams").map(_.asInstanceOf[List[S2S]].toSet[S2S])


### PR DESCRIPTION
fixes a part of EASY-1128

#### When applied it will
* [x] read all SDO files with UTF8 encoding
* [x] proof proper encoding with unit tests

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Create a bag with accents or even non-western alphabets in the EMD, process it and check the output. 

After building `target/sdoPuddings/one-invalid-sha1/dataset/EMD` has a proper accent, but used to have that with db982ab too.

#### related pull requests on github

No technical dependencies but also part of the overall problem.

repo                       | PR
-------------------------- | -----------------
easy-ingest                      | [PR#](PRlink) 
easy-split-multideposit |
