### PR TITLE
EASY-1172 visible to is anonymous by default

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileAccessRights.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/FileAccessRights.scala
@@ -31,6 +31,8 @@ object FileAccessRights extends Enumeration {
   = Value
 
   private val rightsMap = Map[AccessCategory, FileAccessRights.Value](
+    // https://github.com/DANS-KNAW/easy-app/blob/1080eff457/lib/easy-business/src/main/java/nl/knaw/dans/easy/domain/model/AccessibleTo.java#L23-L37
+    // the legacy code lacks OPEN_ACCESS, ACCESS_ELSEWHERE, FREELY_AVAILABLE
     ANONYMOUS_ACCESS -> ANONYMOUS,
     OPEN_ACCESS_FOR_REGISTERED_USERS -> KNOWN,
     GROUP_ACCESS -> RESTRICTED_GROUP,
@@ -53,19 +55,23 @@ object FileAccessRights extends Enumeration {
   def valueOf(s: String): Option[FileAccessRights.Value] =
     FileAccessRights.values.find(v => v.toString == s)
 
-  /** gets the default category of users that have download permission for files in a new dataset
+  /** gets the default category of users that have download permission for files in a new dataset,
+    * an archivist may decide differently
     *
     * @param datasetAccesCategory from the EMD of the dataset
     * @return
     */
   def accessibleTo(datasetAccesCategory: AccessCategory): FileAccessRights.Value =
-    rightsMap.get(datasetAccesCategory).get
+    rightsMap(datasetAccesCategory)
 
-  /** gets the default category of users that have visibility permission for files in a new dataset
+  /** gets the default category of users that have visibility permission for files in a new dataset:
+    * all files are visible unless an archivist decides differently
     *
     * @param datasetAccesCategory from the EMD of the dataset
     * @return
     */
   def visibleTo(datasetAccesCategory: AccessCategory): FileAccessRights.Value =
-    rightsMap.get(datasetAccesCategory).get
+    // https://github.com/DANS-KNAW/easy-app/blob/1080eff457/lib/easy-business/src/main/java/nl/knaw/dans/easy/business/dataset/DatasetIngester.java#L51
+    // https://github.com/DANS-KNAW/easy-app/blob/1080eff457/lib/easy-business/src/main/java/nl/knaw/dans/easy/business/item/ItemIngester.java#L305
+    ANONYMOUS
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -83,7 +83,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
     implicit val s = createSettings(bagitDir, sdoSetDir)
 
     createFileAndFolderSdos(dataDir, DATASET_SDO, OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe a[Success[_]]
-    readFileToString(fileMetadataFile) should include ("<visibleTo>KNOWN</visibleTo>")
+    readFileToString(fileMetadataFile) should include ("<visibleTo>ANONYMOUS</visibleTo>")
     readFileToString(fileMetadataFile) should include ("<accessibleTo>KNOWN</accessibleTo>")
     deleteDirectory(sdoSetDir)
 
@@ -137,7 +137,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
     tmpProps.delete()
   }
 
-  def createProps() = FileUtils.write(tmpProps, "owner=dsowner\nredirect-unset-url=http://unset.dans.knaw.nl")
+  private def createProps() = FileUtils.write(tmpProps, "owner=dsowner\nredirect-unset-url=http://unset.dans.knaw.nl")
 
   def createSettings(bagitDir: File, sdoSetDir: File): Settings = {
     // the user and disciplines should exist in deasy

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileAccesRightsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/FileAccesRightsSpec.scala
@@ -33,16 +33,16 @@ class FileAccesRightsSpec extends FlatSpec with Matchers {
   }
 
   "visibleTo OPEN_ACCESS_FOR_REGISTERED_USERS)" should "properly map" in {
-    FileAccessRights.visibleTo(AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe FileAccessRights.KNOWN
+    FileAccessRights.visibleTo(AccessCategory.OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe FileAccessRights.ANONYMOUS
   }
   "visibleTo GROUP_ACCESS" should "properly map" in {
-    FileAccessRights.visibleTo(AccessCategory.GROUP_ACCESS) shouldBe FileAccessRights.RESTRICTED_GROUP
+    FileAccessRights.visibleTo(AccessCategory.GROUP_ACCESS) shouldBe FileAccessRights.ANONYMOUS
   }
   "visibleTo REQUEST_PERMISSION)" should "properly map" in {
-    FileAccessRights.visibleTo(AccessCategory.REQUEST_PERMISSION) shouldBe FileAccessRights.RESTRICTED_REQUEST
+    FileAccessRights.visibleTo(AccessCategory.REQUEST_PERMISSION) shouldBe FileAccessRights.ANONYMOUS
   }
   "visibleTo NO_ACCESS)" should "properly map" in {
-    FileAccessRights.visibleTo(AccessCategory.NO_ACCESS) shouldBe FileAccessRights.NONE
+    FileAccessRights.visibleTo(AccessCategory.NO_ACCESS) shouldBe FileAccessRights.ANONYMOUS
   }
 
   "accessibleTo OPEN_ACCESS" should "properly map" in {


### PR DESCRIPTION
fixes EASY-1172

#### When applied it will
* set visibility of files always to anonymous
* have comment linking to the legacy code in easy-app
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
