### PR TITLE
EASY-1173: AV materiaal kan afwijkende accessrights hebben

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SYNOPSIS
 --------
 
     easy-stage-dataset -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -m ] \
-                          <EASY-bag> <staged-digital-object-set>
+                          <EASY-deposit> <staged-digital-object-set>
 
     easy-stage-file-item [<options>...] <staged-digital-object-set>
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -39,7 +39,7 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
   val description = """Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x Repository."""
   val synopsis =
     s"""  $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -m ] \\
-       |  ${_________}    <EASY-bag> <staged-digital-object-set>""".stripMargin
+       |  ${_________}    <EASY-deposit> <staged-digital-object-set>""".stripMargin
   banner(s"""
            |  $description
            |

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -129,7 +129,7 @@ object EasyStageDataset {
           sha1 = maybeSha1Map.get.get(bagRelativePath), // first get is checked in advance
           title = title,
           accessibleTo = fileAccessRights,
-          visibleTo = FileAccessRights.ANONYMOUS
+          visibleTo = FileAccessRights.visibleTo(rights)
         )
         _ <- EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> parentSDO)(fis)
       } yield ()

--- a/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
@@ -36,6 +36,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
+import scala.xml.NodeSeq
 
 object EasyStageDataset {
   val log: Logger = LoggerFactory.getLogger(getClass)
@@ -83,7 +84,7 @@ object EasyStageDataset {
     } yield (emdContent, amdContent)
   }
 
-  def createFileAndFolderSdos(dir: File, parentSDO: String, rights: AccessCategory)(implicit s: Settings): Try[Unit] = {
+  def createFileAndFolderSdos(dir: File, parentSDO: String, datasetRights: AccessCategory)(implicit s: Settings): Try[Unit] = {
     val maybeSha1Map: Try[Map[String, String]] = Try {
       val sha1File = "manifest-sha1.txt"
       readFileToString(new File(s.bagitDir, sha1File),"UTF-8")
@@ -114,9 +115,10 @@ object EasyStageDataset {
       for {
         sdoDir <- mkdirSafe(getSDODir(file))
         bagRelativePath = s.bagitDir.toPath.relativize(file.toPath).toString
-        mime <- readMimeType(bagRelativePath)
-        title <- readTitle(bagRelativePath)
-        fileAccessRights <- getFileAccessRights(bagRelativePath)
+        fileMetadata <- readFileMetadata(bagRelativePath)
+        mime <- readMimeType(fileMetadata)
+        title <- readTitle(fileMetadata)
+        fileAccessRights <- getFileAccessRights(fileMetadata)
         fis = FileItemSettings(
           sdoSetDir = s.sdoSetDir,
           file = if (s.stageFileDataAsRedirectDatastreams) None else Some(file),
@@ -129,15 +131,15 @@ object EasyStageDataset {
           sha1 = maybeSha1Map.get.get(bagRelativePath), // first get is checked in advance
           title = title,
           accessibleTo = fileAccessRights,
-          visibleTo = FileAccessRights.visibleTo(rights)
+          visibleTo = FileAccessRights.visibleTo(datasetRights)
         )
         _ <- EasyStageFileItem.createFileSdo(sdoDir, "objectSDO" -> parentSDO)(fis)
       } yield ()
     }
 
-    def getFileAccessRights(filePath: String)(implicit s: Settings): Try[FileAccessRights.Value] = {
-      lazy val defaultRights = FileAccessRights.accessibleTo(rights)
-      readAccessRights(filePath) map {
+    def getFileAccessRights(fileMetadata: NodeSeq)(implicit s: Settings): Try[FileAccessRights.Value] = {
+      lazy val defaultRights = FileAccessRights.accessibleTo(datasetRights)
+      readAccessRights(fileMetadata: NodeSeq) map {
         case Some(fileRightsStr) => FileAccessRights.valueOf(fileRightsStr).getOrElse(defaultRights) // ignore unknown values
         case None => defaultRights
       }

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -52,8 +52,7 @@ object Util {
     for {
       file <- loadBagXML("metadata/files.xml") \\ "files" \ "file"
       if (file \@ "filepath") == filePath
-      node <- file
-    } yield node
+    } yield file
   }
 
   def readMimeType(fileMetadata: NodeSeq)(implicit s: Settings): Try[String] = Try {

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -40,29 +40,37 @@ object Util {
     else "<Unknown error location>"
   }
 
-  private def readFileMetadata(filePath: String, tagName: String)(implicit s: Settings): NodeSeq = {
+  /**
+   * Load file metadata XML file and extract the metadata for the specified file.
+   * Use this as input for further processing and extraction of sub-elements like title and mime type.
+   *
+   * @param filePath Path to the file, relative to the bag
+   * @param s Settings
+   * @return File metadata (XML Nodes) for the specified file
+   */
+  def readFileMetadata(filePath: String)(implicit s: Settings): Try[NodeSeq] = Try {
     for {
       file <- loadBagXML("metadata/files.xml") \\ "files" \ "file"
       if (file \@ "filepath") == filePath
-      node <- file \ tagName
+      node <- file
     } yield node
   }
 
-  def readMimeType(filePath: String)(implicit s: Settings): Try[String] = Try {
-    val mimes =  readFileMetadata(filePath, "format")
+  def readMimeType(fileMetadata: NodeSeq)(implicit s: Settings): Try[String] = Try {
+    val mimes =  fileMetadata \ "format"
     if (mimes.size != 1)
-      throw RejectedDepositException(s"Filepath [$filePath] doesn't exist in files.xml, or isn't unique.")
+      throw RejectedDepositException(s"format element doesn't exist for the file, or isn't unique.")
     mimes.head.text
   }
 
-  def readTitle(filePath: String)(implicit s: Settings): Try[Option[String]] = Try {
-    val titles = readFileMetadata(filePath, "title")
+  def readTitle(fileMetadata: NodeSeq)(implicit s: Settings): Try[Option[String]] = Try {
+    val titles = fileMetadata \ "title"
     if(titles.size == 1) Option(titles.head.text)
     else None
   }
 
-  def readAccessRights(filePath: String)(implicit s: Settings): Try[Option[String]] = Try {
-    val rights = readFileMetadata(filePath, "accessRights")
+  def readAccessRights(fileMetadata: NodeSeq)(implicit s: Settings): Try[Option[String]] = Try {
+    val rights = fileMetadata \ "accessRights"
     if(rights.size == 1) Option(rights.head.text)
     else None
   }

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -43,7 +43,7 @@ object Util {
   private def readFileMetadata(filePath: String, tagName: String)(implicit s: Settings): NodeSeq = {
     for {
       file <- loadBagXML("metadata/files.xml") \\ "files" \ "file"
-      if (file \ "@filepath").text == filePath
+      if (file \@ "filepath") == filePath
       node <- file \ tagName
     } yield node
   }

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala
@@ -22,7 +22,7 @@ import nl.knaw.dans.easy.stage.lib.Util.loadXML
 
 import scala.sys.error
 import scala.util.Try
-import scala.xml.Elem
+import scala.xml.{Elem, NodeSeq}
 
 object Util {
 
@@ -59,6 +59,22 @@ object Util {
     } yield title
     if(titles.size == 1) Option(titles.head.text)
     else None
+  }
+
+  def readAccessRights(filePath: String)(implicit s: Settings): Try[Option[String]] = Try {
+    val rights = readFileMetadata(filePath, "accessRights")
+    if(rights.size == 1) Option(rights.head.text)
+    else None
+    // ? could we do map ?
+  }
+
+  // TODO refactor
+  private def readFileMetadata(filePath: String, tagName: String)(implicit s: Settings): NodeSeq = {
+    for {
+      file <- loadBagXML("metadata/files.xml") \\ "files" \ "file"
+      if (file \ "@filepath").text == filePath
+      node <- file \ tagName
+    } yield node
   }
 
   def readAudiences()(implicit s: Settings): Try[Seq[String]] = Try {

--- a/src/test/resources/dataset-bags/no-additional-license/metadata/files.xml
+++ b/src/test/resources/dataset-bags/no-additional-license/metadata/files.xml
@@ -2,6 +2,7 @@
 <files xmlns:dcterms="http://purl.org/dc/terms/">
     <file filepath="data/path/to/file.txt">
         <dcterms:format>text/plain</dcterms:format>
+        <dcterms:accessRights>NO_ACCESS</dcterms:accessRights>
     </file>
     <file filepath="data/quicksort.hs">
         <dcterms:format>text/plain</dcterms:format>

--- a/src/test/resources/dataset-bags/no-additional-license/metadata/files.xml
+++ b/src/test/resources/dataset-bags/no-additional-license/metadata/files.xml
@@ -2,7 +2,7 @@
 <files xmlns:dcterms="http://purl.org/dc/terms/">
     <file filepath="data/path/to/file.txt">
         <dcterms:format>text/plain</dcterms:format>
-        <dcterms:accessRights>NO_ACCESS</dcterms:accessRights>
+        <dcterms:accessRights>NONE</dcterms:accessRights>
     </file>
     <file filepath="data/quicksort.hs">
         <dcterms:format>text/plain</dcterms:format>

--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -121,7 +121,6 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
     tmpProps.delete()
   }
 
-
   "run" should "create SDO sets from test bags (proof the puddings by eating them with easy-ingest)" in {
     assume(canConnect(xsds))
 

--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -106,7 +106,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
     val fileMetadataFile = new File(sdoSetDir, "path_to_file_txt/EASY_FILE_METADATA")
     implicit val s = createSettings(bagitDir, sdoSetDir)
 
-    // Note that files.xml specifies NO_ACCESS for data/path/to/file.txt
+    // Note that files.xml specifies NONE for data/path/to/file.txt
 
     createFileAndFolderSdos(dataDir, DATASET_SDO, OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe a[Success[_]]
     readFileToString(fileMetadataFile) should include ("<visibleTo>ANONYMOUS</visibleTo>")

--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -73,7 +73,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
     deleteDirectory(bagitDir)
   }
 
-  it should "create file rights computed from dataset access rights" in {
+  it should "create file rights computed from dataset access rights by default" in {
 
     createProps()
     val bagitDir = new File("src/test/resources/dataset-bags/no-additional-license")
@@ -81,6 +81,8 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
     val sdoSetDir = new File("target/test/sdoSet")
     val fileMetadataFile = new File(sdoSetDir, "quicksort_hs/EASY_FILE_METADATA")
     implicit val s = createSettings(bagitDir, sdoSetDir)
+
+    // Note that files.xml specifies no accessRights for data/quicksort.hs
 
     createFileAndFolderSdos(dataDir, DATASET_SDO, OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe a[Success[_]]
     readFileToString(fileMetadataFile) should include ("<visibleTo>ANONYMOUS</visibleTo>")
@@ -94,6 +96,31 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers {
 
     tmpProps.delete()
   }
+
+  it should "override default dataset rights when rights are explicitly specified for a file" in {
+
+    createProps()
+    val bagitDir = new File("src/test/resources/dataset-bags/no-additional-license")
+    val dataDir = new File(bagitDir, "data")
+    val sdoSetDir = new File("target/test/sdoSet")
+    val fileMetadataFile = new File(sdoSetDir, "path_to_file_txt/EASY_FILE_METADATA")
+    implicit val s = createSettings(bagitDir, sdoSetDir)
+
+    // Note that files.xml specifies NO_ACCESS for data/path/to/file.txt
+
+    createFileAndFolderSdos(dataDir, DATASET_SDO, OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe a[Success[_]]
+    readFileToString(fileMetadataFile) should include ("<visibleTo>ANONYMOUS</visibleTo>")
+    readFileToString(fileMetadataFile) should include ("<accessibleTo>NONE</accessibleTo>")
+    deleteDirectory(sdoSetDir)
+
+    createFileAndFolderSdos(dataDir, DATASET_SDO, ANONYMOUS_ACCESS) shouldBe a[Success[_]]
+    readFileToString(fileMetadataFile) should include ("<visibleTo>ANONYMOUS</visibleTo>")
+    readFileToString(fileMetadataFile) should include ("<accessibleTo>NONE</accessibleTo>")
+    deleteDirectory(sdoSetDir)
+
+    tmpProps.delete()
+  }
+
 
   "run" should "create SDO sets from test bags (proof the puddings by eating them with easy-ingest)" in {
     assume(canConnect(xsds))


### PR DESCRIPTION
fixes EASY-1173 AV materiaal kan afwijkende accessrights hebben

#### When applied it will
* use the access rights (accessibleTo) specified in the files.xml metadata if available, otherwise it uses the dataset access rights


#### Where should the reviewer @DANS-KNAW/easy start?
/src/main/scala/nl/knaw/dans/easy/stage/EasyStageDataset.scala
and
/src/main/scala/nl/knaw/dans/easy/stage/dataset/Util.scala

#### How should this be manually tested?
Just run the unit tests, which should succeed, and then inspect the result in: target/sdoPuddings
 
target/sdoPuddings/no-additional-license/path_to_file_txt/EASY_FILE_METADATA
now has `<accessibleTo>NONE</accessibleTo>`

because 
src/test/resources/dataset-bags/no-additional-license/metadata/files.xml
has 
`<dcterms:accessRights>NONE</dcterms:accessRights>`
