### PR TITLE
NO JIRA ISSUE

### DIFF
--- a/src/main/assembly/dist/lic/BY-NC-3.0.html
+++ b/src/main/assembly/dist/lic/BY-NC-3.0.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta name="generator" content="HTML Tidy for Linux/x86 (vers 1 September 2005), see www.w3.org">
+<title>Creative Commons Legal Code</title>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+<!--[if lt IE 7]><link rel="stylesheet" type="text/css" href="https://creativecommons.org/includes/deed3-ie.css" media="screen" /><![endif]-->
+</head>
+<body>
+<p id="header" align="center"><a href="https://creativecommons.org/">Creative Commons</a></p>
+<div id="deed" class="yellow">
+<div id="deed-head">
+<div id="cc-logo">
+</div>
+<h1><span>Creative Commons Legal Code</span></h1>
+<div id="deed-license">
+<h2>Attribution-NonCommercial 3.0 Unported</h2>
+</div>
+</div>
+<div id="deed-main">
+<div id="deed-main-content">
+<blockquote>
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES
+NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE
+DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE
+COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS.
+CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE
+INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR DAMAGES
+RESULTING FROM ITS USE.
+</blockquote>
+<h3><em>License</em></h3>
+<p>THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS
+OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR
+"LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER
+APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS
+PROHIBITED.</p>
+<p>BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU
+ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE.
+TO THE EXTENT THIS LICENSE MAY BE CONSIDERED TO BE A
+CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE
+IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS.</p>
+<p><strong>1. Definitions</strong></p>
+<ol type="a">
+<li><strong>"Adaptation"</strong> means a work based upon
+the Work, or upon the Work and other pre-existing works,
+such as a translation, adaptation, derivative work,
+arrangement of music or other alterations of a literary
+or artistic work, or phonogram or performance and
+includes cinematographic adaptations or any other form in
+which the Work may be recast, transformed, or adapted
+including in any form recognizably derived from the
+original, except that a work that constitutes a
+Collection will not be considered an Adaptation for the
+purpose of this License. For the avoidance of doubt,
+where the Work is a musical work, performance or
+phonogram, the synchronization of the Work in
+timed-relation with a moving image ("synching") will be
+considered an Adaptation for the purpose of this
+License.</li>
+<li><strong>"Collection"</strong> means a collection of
+literary or artistic works, such as encyclopedias and
+anthologies, or performances, phonograms or broadcasts,
+or other works or subject matter other than works listed
+in Section 1(f) below, which, by reason of the selection
+and arrangement of their contents, constitute
+intellectual creations, in which the Work is included in
+its entirety in unmodified form along with one or more
+other contributions, each constituting separate and
+independent works in themselves, which together are
+assembled into a collective whole. A work that
+constitutes a Collection will not be considered an
+Adaptation (as defined above) for the purposes of this
+License.</li>
+<li><strong>"Distribute"</strong> means to make available
+to the public the original and copies of the Work or
+Adaptation, as appropriate, through sale or other
+transfer of ownership.</li>
+<li><strong>"Licensor"</strong> means the individual,
+individuals, entity or entities that offer(s) the Work
+under the terms of this License.</li>
+<li><strong>"Original Author"</strong> means, in the case
+of a literary or artistic work, the individual,
+individuals, entity or entities who created the Work or
+if no individual or entity can be identified, the
+publisher; and in addition (i) in the case of a
+performance the actors, singers, musicians, dancers, and
+other persons who act, sing, deliver, declaim, play in,
+interpret or otherwise perform literary or artistic works
+or expressions of folklore; (ii) in the case of a
+phonogram the producer being the person or legal entity
+who first fixes the sounds of a performance or other
+sounds; and, (iii) in the case of broadcasts, the
+organization that transmits the broadcast.</li>
+<li><strong>"Work"</strong> means the literary and/or
+artistic work offered under the terms of this License
+including without limitation any production in the
+literary, scientific and artistic domain, whatever may be
+the mode or form of its expression including digital
+form, such as a book, pamphlet and other writing; a
+lecture, address, sermon or other work of the same
+nature; a dramatic or dramatico-musical work; a
+choreographic work or entertainment in dumb show; a
+musical composition with or without words; a
+cinematographic work to which are assimilated works
+expressed by a process analogous to cinematography; a
+work of drawing, painting, architecture, sculpture,
+engraving or lithography; a photographic work to which
+are assimilated works expressed by a process analogous to
+photography; a work of applied art; an illustration, map,
+plan, sketch or three-dimensional work relative to
+geography, topography, architecture or science; a
+performance; a broadcast; a phonogram; a compilation of
+data to the extent it is protected as a copyrightable
+work; or a work performed by a variety or circus
+performer to the extent it is not otherwise considered a
+literary or artistic work.</li>
+<li><strong>"You"</strong> means an individual or entity
+exercising rights under this License who has not
+previously violated the terms of this License with
+respect to the Work, or who has received express
+permission from the Licensor to exercise rights under
+this License despite a previous violation.</li>
+<li><strong>"Publicly Perform"</strong> means to perform
+public recitations of the Work and to communicate to the
+public those public recitations, by any means or process,
+including by wire or wireless means or public digital
+performances; to make available to the public Works in
+such a way that members of the public may access these
+Works from a place and at a place individually chosen by
+them; to perform the Work to the public by any means or
+process and the communication to the public of the
+performances of the Work, including by public digital
+performance; to broadcast and rebroadcast the Work by any
+means including signs, sounds or images.</li>
+<li><strong>"Reproduce"</strong> means to make copies of
+the Work by any means including without limitation by
+sound or visual recordings and the right of fixation and
+reproducing fixations of the Work, including storage of a
+protected performance or phonogram in digital form or
+other electronic medium.</li>
+</ol>
+<p><strong>2. Fair Dealing Rights.</strong> Nothing in this
+License is intended to reduce, limit, or restrict any uses
+free from copyright or rights arising from limitations or
+exceptions that are provided for in connection with the
+copyright protection under copyright law or other
+applicable laws.</p>
+<p><strong>3. License Grant.</strong> Subject to the terms
+and conditions of this License, Licensor hereby grants You
+a worldwide, royalty-free, non-exclusive, perpetual (for
+the duration of the applicable copyright) license to
+exercise the rights in the Work as stated below:</p>
+<ol type="a">
+<li>to Reproduce the Work, to incorporate the Work into
+one or more Collections, and to Reproduce the Work as
+incorporated in the Collections;</li>
+<li>to create and Reproduce Adaptations provided that any
+such Adaptation, including any translation in any medium,
+takes reasonable steps to clearly label, demarcate or
+otherwise identify that changes were made to the original
+Work. For example, a translation could be marked "The
+original work was translated from English to Spanish," or
+a modification could indicate "The original work has been
+modified.";</li>
+<li>to Distribute and Publicly Perform the Work including
+as incorporated in Collections; and,</li>
+<li>to Distribute and Publicly Perform Adaptations.</li>
+</ol>
+<p>The above rights may be exercised in all media and
+formats whether now known or hereafter devised. The above
+rights include the right to make such modifications as are
+technically necessary to exercise the rights in other media
+and formats. Subject to Section 8(f), all rights not
+expressly granted by Licensor are hereby reserved,
+including but not limited to the rights set forth in
+Section 4(d).</p>
+<p><strong>4. Restrictions.</strong> The license granted in
+Section 3 above is expressly made subject to and limited by
+the following restrictions:</p>
+<ol type="a">
+<li>You may Distribute or Publicly Perform the Work only
+under the terms of this License. You must include a copy
+of, or the Uniform Resource Identifier (URI) for, this
+License with every copy of the Work You Distribute or
+Publicly Perform. You may not offer or impose any terms
+on the Work that restrict the terms of this License or
+the ability of the recipient of the Work to exercise the
+rights granted to that recipient under the terms of the
+License. You may not sublicense the Work. You must keep
+intact all notices that refer to this License and to the
+disclaimer of warranties with every copy of the Work You
+Distribute or Publicly Perform. When You Distribute or
+Publicly Perform the Work, You may not impose any
+effective technological measures on the Work that
+restrict the ability of a recipient of the Work from You
+to exercise the rights granted to that recipient under
+the terms of the License. This Section 4(a) applies to
+the Work as incorporated in a Collection, but this does
+not require the Collection apart from the Work itself to
+be made subject to the terms of this License. If You
+create a Collection, upon notice from any Licensor You
+must, to the extent practicable, remove from the
+Collection any credit as required by Section 4(c), as
+requested. If You create an Adaptation, upon notice from
+any Licensor You must, to the extent practicable, remove
+from the Adaptation any credit as required by Section
+4(c), as requested.</li>
+<li>You may not exercise any of the rights granted to You
+in Section 3 above in any manner that is primarily
+intended for or directed toward commercial advantage or
+private monetary compensation. The exchange of the Work
+for other copyrighted works by means of digital
+file-sharing or otherwise shall not be considered to be
+intended for or directed toward commercial advantage or
+private monetary compensation, provided there is no
+payment of any monetary compensation in connection with
+the exchange of copyrighted works.</li>
+<li>If You Distribute, or Publicly Perform the Work or
+any Adaptations or Collections, You must, unless a
+request has been made pursuant to Section 4(a), keep
+intact all copyright notices for the Work and provide,
+reasonable to the medium or means You are utilizing: (i)
+the name of the Original Author (or pseudonym, if
+applicable) if supplied, and/or if the Original Author
+and/or Licensor designate another party or parties (e.g.,
+a sponsor institute, publishing entity, journal) for
+attribution ("Attribution Parties") in Licensor's
+copyright notice, terms of service or by other reasonable
+means, the name of such party or parties; (ii) the title
+of the Work if supplied; (iii) to the extent reasonably
+practicable, the URI, if any, that Licensor specifies to
+be associated with the Work, unless such URI does not
+refer to the copyright notice or licensing information
+for the Work; and, (iv) consistent with Section 3(b), in
+the case of an Adaptation, a credit identifying the use
+of the Work in the Adaptation (e.g., "French translation
+of the Work by Original Author," or "Screenplay based on
+original Work by Original Author"). The credit required
+by this Section 4(c) may be implemented in any reasonable
+manner; provided, however, that in the case of a
+Adaptation or Collection, at a minimum such credit will
+appear, if a credit for all contributing authors of the
+Adaptation or Collection appears, then as part of these
+credits and in a manner at least as prominent as the
+credits for the other contributing authors. For the
+avoidance of doubt, You may only use the credit required
+by this Section for the purpose of attribution in the
+manner set out above and, by exercising Your rights under
+this License, You may not implicitly or explicitly assert
+or imply any connection with, sponsorship or endorsement
+by the Original Author, Licensor and/or Attribution
+Parties, as appropriate, of You or Your use of the Work,
+without the separate, express prior written permission of
+the Original Author, Licensor and/or Attribution
+Parties.</li>
+<li>
+<p>For the avoidance of doubt:</p>
+<ol type="i">
+<li><strong>Non-waivable Compulsory License
+Schemes</strong>. In those jurisdictions in which the
+right to collect royalties through any statutory or
+compulsory licensing scheme cannot be waived, the
+Licensor reserves the exclusive right to collect such
+royalties for any exercise by You of the rights
+granted under this License;</li>
+<li><strong>Waivable Compulsory License
+Schemes</strong>. In those jurisdictions in which the
+right to collect royalties through any statutory or
+compulsory licensing scheme can be waived, the
+Licensor reserves the exclusive right to collect such
+royalties for any exercise by You of the rights
+granted under this License if Your exercise of such
+rights is for a purpose or use which is otherwise
+than noncommercial as permitted under Section 4(b)
+and otherwise waives the right to collect royalties
+through any statutory or compulsory licensing scheme;
+and,</li>
+<li><strong>Voluntary License Schemes</strong>. The
+Licensor reserves the right to collect royalties,
+whether individually or, in the event that the
+Licensor is a member of a collecting society that
+administers voluntary licensing schemes, via that
+society, from any exercise by You of the rights
+granted under this License that is for a purpose or
+use which is otherwise than noncommercial as
+permitted under Section 4(c).</li>
+</ol>
+</li>
+<li>Except as otherwise agreed in writing by the Licensor
+or as may be otherwise permitted by applicable law, if
+You Reproduce, Distribute or Publicly Perform the Work
+either by itself or as part of any Adaptations or
+Collections, You must not distort, mutilate, modify or
+take other derogatory action in relation to the Work
+which would be prejudicial to the Original Author's honor
+or reputation. Licensor agrees that in those
+jurisdictions (e.g. Japan), in which any exercise of the
+right granted in Section 3(b) of this License (the right
+to make Adaptations) would be deemed to be a distortion,
+mutilation, modification or other derogatory action
+prejudicial to the Original Author's honor and
+reputation, the Licensor will waive or not assert, as
+appropriate, this Section, to the fullest extent
+permitted by the applicable national law, to enable You
+to reasonably exercise Your right under Section 3(b) of
+this License (right to make Adaptations) but not
+otherwise.</li>
+</ol>
+<p><strong>5. Representations, Warranties and
+Disclaimer</strong></p>
+<p>UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN
+WRITING, LICENSOR OFFERS THE WORK AS-IS AND MAKES NO
+REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE
+WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING,
+WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE
+ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR THE
+PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
+SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED
+WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.</p>
+<p><strong>6. Limitation on Liability.</strong> EXCEPT TO
+THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL
+LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY
+SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK,
+EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.</p>
+<p><strong>7. Termination</strong></p>
+<ol type="a">
+<li>This License and the rights granted hereunder will
+terminate automatically upon any breach by You of the
+terms of this License. Individuals or entities who have
+received Adaptations or Collections from You under this
+License, however, will not have their licenses terminated
+provided such individuals or entities remain in full
+compliance with those licenses. Sections 1, 2, 5, 6, 7,
+and 8 will survive any termination of this License.</li>
+<li>Subject to the above terms and conditions, the
+license granted here is perpetual (for the duration of
+the applicable copyright in the Work). Notwithstanding
+the above, Licensor reserves the right to release the
+Work under different license terms or to stop
+distributing the Work at any time; provided, however that
+any such election will not serve to withdraw this License
+(or any other license that has been, or is required to
+be, granted under the terms of this License), and this
+License will continue in full force and effect unless
+terminated as stated above.</li>
+</ol>
+<p><strong>8. Miscellaneous</strong></p>
+<ol type="a">
+<li>Each time You Distribute or Publicly Perform the Work
+or a Collection, the Licensor offers to the recipient a
+license to the Work on the same terms and conditions as
+the license granted to You under this License.</li>
+<li>Each time You Distribute or Publicly Perform an
+Adaptation, Licensor offers to the recipient a license to
+the original Work on the same terms and conditions as the
+license granted to You under this License.</li>
+<li>If any provision of this License is invalid or
+unenforceable under applicable law, it shall not affect
+the validity or enforceability of the remainder of the
+terms of this License, and without further action by the
+parties to this agreement, such provision shall be
+reformed to the minimum extent necessary to make such
+provision valid and enforceable.</li>
+<li>No term or provision of this License shall be deemed
+waived and no breach consented to unless such waiver or
+consent shall be in writing and signed by the party to be
+charged with such waiver or consent.</li>
+<li>This License constitutes the entire agreement between
+the parties with respect to the Work licensed here. There
+are no understandings, agreements or representations with
+respect to the Work not specified here. Licensor shall
+not be bound by any additional provisions that may appear
+in any communication from You. This License may not be
+modified without the mutual written agreement of the
+Licensor and You.</li>
+<li>The rights granted under, and the subject matter
+referenced, in this License were drafted utilizing the
+terminology of the Berne Convention for the Protection of
+Literary and Artistic Works (as amended on September 28,
+1979), the Rome Convention of 1961, the WIPO Copyright
+Treaty of 1996, the WIPO Performances and Phonograms
+Treaty of 1996 and the Universal Copyright Convention (as
+revised on July 24, 1971). These rights and subject
+matter take effect in the relevant jurisdiction in which
+the License terms are sought to be enforced according to
+the corresponding provisions of the implementation of
+those treaty provisions in the applicable national law.
+If the standard suite of rights granted under applicable
+copyright law includes additional rights not granted
+under this License, such additional rights are deemed to
+be included in the License; this License is not intended
+to restrict the license of any rights under applicable
+law.</li>
+</ol>
+ 
+<blockquote>
+<h3>Creative Commons Notice</h3>
+<p>Creative Commons is not a party to this License, and
+makes no warranty whatsoever in connection with the Work.
+Creative Commons will not be liable to You or any party
+on any legal theory for any damages whatsoever, including
+without limitation any general, special, incidental or
+consequential damages arising in connection to this
+license. Notwithstanding the foregoing two (2) sentences,
+if Creative Commons has expressly identified itself as
+the Licensor hereunder, it shall have all rights and
+obligations of Licensor.</p>
+<p>Except for the limited purpose of indicating to the
+public that the Work is licensed under the CCPL, Creative
+Commons does not authorize the use by either party of the
+trademark "Creative Commons" or any related trademark or
+logo of Creative Commons without the prior written
+consent of Creative Commons. Any permitted use will be in
+compliance with Creative Commons' then-current trademark
+usage guidelines, as may be published on its website or
+otherwise made available upon request from time to time.
+For the avoidance of doubt, this trademark restriction
+does not form part of the License.</p>
+<p>Creative Commons may be contacted at <a href="https://creativecommons.org/">https://creativecommons.org/</a>.</p>
+</blockquote> 
+</div>
+</div>
+<div id="deed-foot">
+<p id="footer"><a href="https://creativecommons.org/licenses/by-nc/3.0/">« Back to Commons Deed</a></p>
+</div>
+</div>
+
+
+</body></html>

--- a/src/main/assembly/dist/lic/BY-NC-SA-3.0.html
+++ b/src/main/assembly/dist/lic/BY-NC-SA-3.0.html
@@ -1,0 +1,461 @@
+<html><head>
+    <title>Creative Commons Legal Code</title>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+</head>
+<body>
+<p id="header" align="center"><a href="https://creativecommons.org/">Creative Commons</a></p>
+<div id="deed" class="yellow">
+    <div id="deed-head">
+        <div id="cc-logo">
+        </div>
+        <h1><span>Creative Commons Legal Code</span></h1>
+        <div id="deed-license">
+            <h2>Attribution-NonCommercial-ShareAlike 3.0 Unported</h2>
+        </div>
+    </div>
+    <div id="deed-main">
+        <div id="deed-main-content">
+            <blockquote>
+                CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES
+                NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE
+                DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE
+                COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS.
+                CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE
+                INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR DAMAGES
+                RESULTING FROM ITS USE.
+            </blockquote>
+            <h3><em>License</em></h3>
+            <p>THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS
+                OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR
+                "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER
+                APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+                AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS
+                PROHIBITED.</p>
+            <p>BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU
+                ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE.
+                TO THE EXTENT THIS LICENSE MAY BE CONSIDERED TO BE A
+                CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE
+                IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+                CONDITIONS.</p>
+            <p><strong>1. Definitions</strong></p>
+            <ol type="a">
+                <li><strong>"Adaptation"</strong> means a work based upon
+                    the Work, or upon the Work and other pre-existing works,
+                    such as a translation, adaptation, derivative work,
+                    arrangement of music or other alterations of a literary
+                    or artistic work, or phonogram or performance and
+                    includes cinematographic adaptations or any other form in
+                    which the Work may be recast, transformed, or adapted
+                    including in any form recognizably derived from the
+                    original, except that a work that constitutes a
+                    Collection will not be considered an Adaptation for the
+                    purpose of this License. For the avoidance of doubt,
+                    where the Work is a musical work, performance or
+                    phonogram, the synchronization of the Work in
+                    timed-relation with a moving image ("synching") will be
+                    considered an Adaptation for the purpose of this
+                    License.</li>
+                <li><strong>"Collection"</strong> means a collection of
+                    literary or artistic works, such as encyclopedias and
+                    anthologies, or performances, phonograms or broadcasts,
+                    or other works or subject matter other than works listed
+                    in Section 1(g) below, which, by reason of the selection
+                    and arrangement of their contents, constitute
+                    intellectual creations, in which the Work is included in
+                    its entirety in unmodified form along with one or more
+                    other contributions, each constituting separate and
+                    independent works in themselves, which together are
+                    assembled into a collective whole. A work that
+                    constitutes a Collection will not be considered an
+                    Adaptation (as defined above) for the purposes of this
+                    License.</li>
+                <li><strong>"Distribute"</strong> means to make available
+                    to the public the original and copies of the Work or
+                    Adaptation, as appropriate, through sale or other
+                    transfer of ownership.</li>
+                <li><strong>"License Elements"</strong> means the
+                    following high-level license attributes as selected by
+                    Licensor and indicated in the title of this License:
+                    Attribution, Noncommercial, ShareAlike.</li>
+                <li><strong>"Licensor"</strong> means the individual,
+                    individuals, entity or entities that offer(s) the Work
+                    under the terms of this License.</li>
+                <li><strong>"Original Author"</strong> means, in the case
+                    of a literary or artistic work, the individual,
+                    individuals, entity or entities who created the Work or
+                    if no individual or entity can be identified, the
+                    publisher; and in addition (i) in the case of a
+                    performance the actors, singers, musicians, dancers, and
+                    other persons who act, sing, deliver, declaim, play in,
+                    interpret or otherwise perform literary or artistic works
+                    or expressions of folklore; (ii) in the case of a
+                    phonogram the producer being the person or legal entity
+                    who first fixes the sounds of a performance or other
+                    sounds; and, (iii) in the case of broadcasts, the
+                    organization that transmits the broadcast.</li>
+                <li><strong>"Work"</strong> means the literary and/or
+                    artistic work offered under the terms of this License
+                    including without limitation any production in the
+                    literary, scientific and artistic domain, whatever may be
+                    the mode or form of its expression including digital
+                    form, such as a book, pamphlet and other writing; a
+                    lecture, address, sermon or other work of the same
+                    nature; a dramatic or dramatico-musical work; a
+                    choreographic work or entertainment in dumb show; a
+                    musical composition with or without words; a
+                    cinematographic work to which are assimilated works
+                    expressed by a process analogous to cinematography; a
+                    work of drawing, painting, architecture, sculpture,
+                    engraving or lithography; a photographic work to which
+                    are assimilated works expressed by a process analogous to
+                    photography; a work of applied art; an illustration, map,
+                    plan, sketch or three-dimensional work relative to
+                    geography, topography, architecture or science; a
+                    performance; a broadcast; a phonogram; a compilation of
+                    data to the extent it is protected as a copyrightable
+                    work; or a work performed by a variety or circus
+                    performer to the extent it is not otherwise considered a
+                    literary or artistic work.</li>
+                <li><strong>"You"</strong> means an individual or entity
+                    exercising rights under this License who has not
+                    previously violated the terms of this License with
+                    respect to the Work, or who has received express
+                    permission from the Licensor to exercise rights under
+                    this License despite a previous violation.</li>
+                <li><strong>"Publicly Perform"</strong> means to perform
+                    public recitations of the Work and to communicate to the
+                    public those public recitations, by any means or process,
+                    including by wire or wireless means or public digital
+                    performances; to make available to the public Works in
+                    such a way that members of the public may access these
+                    Works from a place and at a place individually chosen by
+                    them; to perform the Work to the public by any means or
+                    process and the communication to the public of the
+                    performances of the Work, including by public digital
+                    performance; to broadcast and rebroadcast the Work by any
+                    means including signs, sounds or images.</li>
+                <li><strong>"Reproduce"</strong> means to make copies of
+                    the Work by any means including without limitation by
+                    sound or visual recordings and the right of fixation and
+                    reproducing fixations of the Work, including storage of a
+                    protected performance or phonogram in digital form or
+                    other electronic medium.</li>
+            </ol>
+            <p><strong>2. Fair Dealing Rights.</strong> Nothing in this
+                License is intended to reduce, limit, or restrict any uses
+                free from copyright or rights arising from limitations or
+                exceptions that are provided for in connection with the
+                copyright protection under copyright law or other
+                applicable laws.</p>
+            <p><strong>3. License Grant.</strong> Subject to the terms
+                and conditions of this License, Licensor hereby grants You
+                a worldwide, royalty-free, non-exclusive, perpetual (for
+                the duration of the applicable copyright) license to
+                exercise the rights in the Work as stated below:</p>
+            <ol type="a">
+                <li>to Reproduce the Work, to incorporate the Work into
+                    one or more Collections, and to Reproduce the Work as
+                    incorporated in the Collections;</li>
+                <li>to create and Reproduce Adaptations provided that any
+                    such Adaptation, including any translation in any medium,
+                    takes reasonable steps to clearly label, demarcate or
+                    otherwise identify that changes were made to the original
+                    Work. For example, a translation could be marked "The
+                    original work was translated from English to Spanish," or
+                    a modification could indicate "The original work has been
+                    modified.";</li>
+                <li>to Distribute and Publicly Perform the Work including
+                    as incorporated in Collections; and,</li>
+                <li>to Distribute and Publicly Perform Adaptations.</li>
+            </ol>
+            <p>The above rights may be exercised in all media and
+                formats whether now known or hereafter devised. The above
+                rights include the right to make such modifications as are
+                technically necessary to exercise the rights in other media
+                and formats. Subject to Section 8(f), all rights not
+                expressly granted by Licensor are hereby reserved,
+                including but not limited to the rights described in
+                Section 4(e).</p>
+            <p><strong>4. Restrictions.</strong> The license granted in
+                Section 3 above is expressly made subject to and limited by
+                the following restrictions:</p>
+            <ol type="a">
+                <li>You may Distribute or Publicly Perform the Work only
+                    under the terms of this License. You must include a copy
+                    of, or the Uniform Resource Identifier (URI) for, this
+                    License with every copy of the Work You Distribute or
+                    Publicly Perform. You may not offer or impose any terms
+                    on the Work that restrict the terms of this License or
+                    the ability of the recipient of the Work to exercise the
+                    rights granted to that recipient under the terms of the
+                    License. You may not sublicense the Work. You must keep
+                    intact all notices that refer to this License and to the
+                    disclaimer of warranties with every copy of the Work You
+                    Distribute or Publicly Perform. When You Distribute or
+                    Publicly Perform the Work, You may not impose any
+                    effective technological measures on the Work that
+                    restrict the ability of a recipient of the Work from You
+                    to exercise the rights granted to that recipient under
+                    the terms of the License. This Section 4(a) applies to
+                    the Work as incorporated in a Collection, but this does
+                    not require the Collection apart from the Work itself to
+                    be made subject to the terms of this License. If You
+                    create a Collection, upon notice from any Licensor You
+                    must, to the extent practicable, remove from the
+                    Collection any credit as required by Section 4(d), as
+                    requested. If You create an Adaptation, upon notice from
+                    any Licensor You must, to the extent practicable, remove
+                    from the Adaptation any credit as required by Section
+                    4(d), as requested.</li>
+                <li>You may Distribute or Publicly Perform an Adaptation
+                    only under: (i) the terms of this License; (ii) a later
+                    version of this License with the same License Elements as
+                    this License; (iii) a Creative Commons jurisdiction
+                    license (either this or a later license version) that
+                    contains the same License Elements as this License (e.g.,
+                    Attribution-NonCommercial-ShareAlike 3.0 US) ("Applicable
+                    License"). You must include a copy of, or the URI, for
+                    Applicable License with every copy of each Adaptation You
+                    Distribute or Publicly Perform. You may not offer or
+                    impose any terms on the Adaptation that restrict the
+                    terms of the Applicable License or the ability of the
+                    recipient of the Adaptation to exercise the rights
+                    granted to that recipient under the terms of the
+                    Applicable License. You must keep intact all notices that
+                    refer to the Applicable License and to the disclaimer of
+                    warranties with every copy of the Work as included in the
+                    Adaptation You Distribute or Publicly Perform. When You
+                    Distribute or Publicly Perform the Adaptation, You may
+                    not impose any effective technological measures on the
+                    Adaptation that restrict the ability of a recipient of
+                    the Adaptation from You to exercise the rights granted to
+                    that recipient under the terms of the Applicable License.
+                    This Section 4(b) applies to the Adaptation as
+                    incorporated in a Collection, but this does not require
+                    the Collection apart from the Adaptation itself to be
+                    made subject to the terms of the Applicable License.</li>
+                <li>You may not exercise any of the rights granted to You
+                    in Section 3 above in any manner that is primarily
+                    intended for or directed toward commercial advantage or
+                    private monetary compensation. The exchange of the Work
+                    for other copyrighted works by means of digital
+                    file-sharing or otherwise shall not be considered to be
+                    intended for or directed toward commercial advantage or
+                    private monetary compensation, provided there is no
+                    payment of any monetary compensation in con-nection with
+                    the exchange of copyrighted works.</li>
+                <li>If You Distribute, or Publicly Perform the Work or
+                    any Adaptations or Collections, You must, unless a
+                    request has been made pursuant to Section 4(a), keep
+                    intact all copyright notices for the Work and provide,
+                    reasonable to the medium or means You are utilizing: (i)
+                    the name of the Original Author (or pseudonym, if
+                    applicable) if supplied, and/or if the Original Author
+                    and/or Licensor designate another party or parties (e.g.,
+                    a sponsor institute, publishing entity, journal) for
+                    attribution ("Attribution Parties") in Licensor's
+                    copyright notice, terms of service or by other reasonable
+                    means, the name of such party or parties; (ii) the title
+                    of the Work if supplied; (iii) to the extent reasonably
+                    practicable, the URI, if any, that Licensor specifies to
+                    be associated with the Work, unless such URI does not
+                    refer to the copyright notice or licensing information
+                    for the Work; and, (iv) consistent with Section 3(b), in
+                    the case of an Adaptation, a credit identifying the use
+                    of the Work in the Adaptation (e.g., "French translation
+                    of the Work by Original Author," or "Screenplay based on
+                    original Work by Original Author"). The credit required
+                    by this Section 4(d) may be implemented in any reasonable
+                    manner; provided, however, that in the case of a
+                    Adaptation or Collection, at a minimum such credit will
+                    appear, if a credit for all contributing authors of the
+                    Adaptation or Collection appears, then as part of these
+                    credits and in a manner at least as prominent as the
+                    credits for the other contributing authors. For the
+                    avoidance of doubt, You may only use the credit required
+                    by this Section for the purpose of attribution in the
+                    manner set out above and, by exercising Your rights under
+                    this License, You may not implicitly or explicitly assert
+                    or imply any connection with, sponsorship or endorsement
+                    by the Original Author, Licensor and/or Attribution
+                    Parties, as appropriate, of You or Your use of the Work,
+                    without the separate, express prior written permission of
+                    the Original Author, Licensor and/or Attribution
+                    Parties.</li>
+                <li>
+                    <p>For the avoidance of doubt:</p>
+                    <ol type="i">
+                        <li><strong>Non-waivable Compulsory License
+                            Schemes</strong>. In those jurisdictions in which the
+                            right to collect royalties through any statutory or
+                            compulsory licensing scheme cannot be waived, the
+                            Licensor reserves the exclusive right to collect such
+                            royalties for any exercise by You of the rights
+                            granted under this License;</li>
+                        <li><strong>Waivable Compulsory License
+                            Schemes</strong>. In those jurisdictions in which the
+                            right to collect royalties through any statutory or
+                            compulsory licensing scheme can be waived, the
+                            Licensor reserves the exclusive right to collect such
+                            royalties for any exercise by You of the rights
+                            granted under this License if Your exercise of such
+                            rights is for a purpose or use which is otherwise
+                            than noncommercial as permitted under Section 4(c)
+                            and otherwise waives the right to collect royalties
+                            through any statutory or compulsory licensing scheme;
+                            and,</li>
+                        <li><strong>Voluntary License Schemes</strong>. The
+                            Licensor reserves the right to collect royalties,
+                            whether individually or, in the event that the
+                            Licensor is a member of a collecting society that
+                            administers voluntary licensing schemes, via that
+                            society, from any exercise by You of the rights
+                            granted under this License that is for a purpose or
+                            use which is otherwise than noncommercial as
+                            permitted under Section 4(c).</li>
+                    </ol>
+                </li>
+                <li>Except as otherwise agreed in writing by the Licensor
+                    or as may be otherwise permitted by applicable law, if
+                    You Reproduce, Distribute or Publicly Perform the Work
+                    either by itself or as part of any Adaptations or
+                    Collections, You must not distort, mutilate, modify or
+                    take other derogatory action in relation to the Work
+                    which would be prejudicial to the Original Author's honor
+                    or reputation. Licensor agrees that in those
+                    jurisdictions (e.g. Japan), in which any exercise of the
+                    right granted in Section 3(b) of this License (the right
+                    to make Adaptations) would be deemed to be a distortion,
+                    mutilation, modification or other derogatory action
+                    prejudicial to the Original Author's honor and
+                    reputation, the Licensor will waive or not assert, as
+                    appropriate, this Section, to the fullest extent
+                    permitted by the applicable national law, to enable You
+                    to reasonably exercise Your right under Section 3(b) of
+                    this License (right to make Adaptations) but not
+                    otherwise.</li>
+            </ol>
+            <p><strong>5. Representations, Warranties and
+                Disclaimer</strong></p>
+            <p>UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN
+                WRITING AND TO THE FULLEST EXTENT PERMITTED BY APPLICABLE
+                LAW, LICENSOR OFFERS THE WORK AS-IS AND MAKES NO
+                REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE
+                WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING,
+                WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE
+                ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR THE
+                PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
+                SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED
+                WARRANTIES, SO THIS EXCLUSION MAY NOT APPLY TO YOU.</p>
+            <p><strong>6. Limitation on Liability.</strong> EXCEPT TO
+                THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL
+                LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY
+                SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY
+                DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK,
+                EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF
+                SUCH DAMAGES.</p>
+            <p><strong>7. Termination</strong></p>
+            <ol type="a">
+                <li>This License and the rights granted hereunder will
+                    terminate automatically upon any breach by You of the
+                    terms of this License. Individuals or entities who have
+                    received Adaptations or Collections from You under this
+                    License, however, will not have their licenses terminated
+                    provided such individuals or entities remain in full
+                    compliance with those licenses. Sections 1, 2, 5, 6, 7,
+                    and 8 will survive any termination of this License.</li>
+                <li>Subject to the above terms and conditions, the
+                    license granted here is perpetual (for the duration of
+                    the applicable copyright in the Work). Notwithstanding
+                    the above, Licensor reserves the right to release the
+                    Work under different license terms or to stop
+                    distributing the Work at any time; provided, however that
+                    any such election will not serve to withdraw this License
+                    (or any other license that has been, or is required to
+                    be, granted under the terms of this License), and this
+                    License will continue in full force and effect unless
+                    terminated as stated above.</li>
+            </ol>
+            <p><strong>8. Miscellaneous</strong></p>
+            <ol type="a">
+                <li>Each time You Distribute or Publicly Perform the Work
+                    or a Collection, the Licensor offers to the recipient a
+                    license to the Work on the same terms and conditions as
+                    the license granted to You under this License.</li>
+                <li>Each time You Distribute or Publicly Perform an
+                    Adaptation, Licensor offers to the recipient a license to
+                    the original Work on the same terms and conditions as the
+                    license granted to You under this License.</li>
+                <li>If any provision of this License is invalid or
+                    unenforceable under applicable law, it shall not affect
+                    the validity or enforceability of the remainder of the
+                    terms of this License, and without further action by the
+                    parties to this agreement, such provision shall be
+                    reformed to the minimum extent necessary to make such
+                    provision valid and enforceable.</li>
+                <li>No term or provision of this License shall be deemed
+                    waived and no breach consented to unless such waiver or
+                    consent shall be in writing and signed by the party to be
+                    charged with such waiver or consent.</li>
+                <li>This License constitutes the entire agreement between
+                    the parties with respect to the Work licensed here. There
+                    are no understandings, agreements or representations with
+                    respect to the Work not specified here. Licensor shall
+                    not be bound by any additional provisions that may appear
+                    in any communication from You. This License may not be
+                    modified without the mutual written agreement of the
+                    Licensor and You.</li>
+                <li>The rights granted under, and the subject matter
+                    referenced, in this License were drafted utilizing the
+                    terminology of the Berne Convention for the Protection of
+                    Literary and Artistic Works (as amended on September 28,
+                    1979), the Rome Convention of 1961, the WIPO Copyright
+                    Treaty of 1996, the WIPO Performances and Phonograms
+                    Treaty of 1996 and the Universal Copyright Convention (as
+                    revised on July 24, 1971). These rights and subject
+                    matter take effect in the relevant jurisdiction in which
+                    the License terms are sought to be enforced according to
+                    the corresponding provisions of the implementation of
+                    those treaty provisions in the applicable national law.
+                    If the standard suite of rights granted under applicable
+                    copyright law includes additional rights not granted
+                    under this License, such additional rights are deemed to
+                    be included in the License; this License is not intended
+                    to restrict the license of any rights under applicable
+                    law.</li>
+            </ol>
+
+            <blockquote>
+                <h3>Creative Commons Notice</h3>
+                <p>Creative Commons is not a party to this License, and
+                    makes no warranty whatsoever in connection with the Work.
+                    Creative Commons will not be liable to You or any party
+                    on any legal theory for any damages whatsoever, including
+                    without limitation any general, special, incidental or
+                    consequential damages arising in connection to this
+                    license. Notwithstanding the foregoing two (2) sentences,
+                    if Creative Commons has expressly identified itself as
+                    the Licensor hereunder, it shall have all rights and
+                    obligations of Licensor.</p>
+                <p>Except for the limited purpose of indicating to the
+                    public that the Work is licensed under the CCPL, Creative
+                    Commons does not authorize the use by either party of the
+                    trademark "Creative Commons" or any related trademark or
+                    logo of Creative Commons without the prior written
+                    consent of Creative Commons. Any permitted use will be in
+                    compliance with Creative Commons' then-current trademark
+                    usage guidelines, as may be published on its website or
+                    otherwise made available upon request from time to time.
+                    For the avoidance of doubt, this trademark restriction
+                    does not form part of this License.</p>
+                <p>Creative Commons may be contacted at <a href="https://creativecommons.org/">https://creativecommons.org/</a>.</p>
+            </blockquote>
+        </div>
+    </div>
+    <div id="deed-foot">
+    </div>
+</div>
+
+
+</body></html>

--- a/src/main/assembly/dist/lic/CERN-OHL-1.1.txt
+++ b/src/main/assembly/dist/lic/CERN-OHL-1.1.txt
@@ -1,0 +1,168 @@
+CERN OPEN HARDWARE LICENCE v1.1
+
+Preamble
+
+Through this CERN Open Hardware Licence ("CERN OHL") version 1.1, the
+Organization wishes to disseminate its hardware designs (as published
+on http://www.ohwr.org/) as widely as possible, and generally to
+foster collaboration among public research hardware designers.  The
+CERN OHL is copyright of CERN. Anyone is welcome to use the CERN OHL,
+in unmodified form only, for the distribution of his own Open Hardware
+designs. Any other right is reserved.
+
+1. Definitions
+
+In this Licence, the following terms have the following meanings:
+
+“Licence” means this CERN OHL.
+
+“Documentation” means schematic diagrams, designs, circuit or circuit
+board layouts, mechanical drawings, flow charts and descriptive text,
+and other explanatory material that is explicitly stated as being made
+available under the conditions of this Licence. The Documentation may
+be in any medium, including but not limited to computer files and
+representations on paper, film, or any other media.
+
+“Product” means either an entire, or any part of a, device built using
+the Documentation or the modified Documentation.
+
+“Licensee” means any natural or legal person exercising rights under
+this Licence.
+
+“Licensor” means any natural or legal person that creates or modifies
+Documentation and subsequently communicates to the public and/ or
+distributes the resulting Documentation under the terms and conditions
+of this Licence.
+
+A Licensee may at the same time be a Licensor, and vice versa.
+
+2. Applicability
+
+2.1 This Licence governs the use, copying, modification, communication
+to the public and distribution of the Documentation, and the
+manufacture and distribution of Products. By exercising any right
+granted under this Licence, the Licensee irrevocably accepts these
+terms and conditions.
+
+2.2 This Licence is granted by the Licensor directly to the Licensee,
+and shall apply worldwide and without limitation in time. The Licensee
+may assign his licence rights or grant sub-licences.
+
+2.3 This Licence does not apply to software, firmware, or code loaded
+into programmable devices which may be used in conjunction with the
+Documentation, the modified Documentation or with Products. The use of
+such software, firmware, or code is subject to the applicable licence
+terms and conditions.
+
+3. Copying, modification, communication to the public and distribution
+of the Documentation
+
+3.1 The Licensee shall keep intact all copyright and trademarks
+notices and all notices that refer to this Licence and to the
+disclaimer of warranties that is included in the Documentation. He
+shall include a copy thereof in every copy of the Documentation or, as
+the case may be, modified Documentation, that he communicates to the
+public or distributes.
+
+3.2 The Licensee may use, copy, communicate to the public and
+distribute verbatim copies of the Documentation, in any medium,
+subject to the requirements specified in section 3.1.
+
+3.3 The Licensee may modify the Documentation or any portion
+thereof. The Licensee may communicate to the public and distribute the
+modified Documentation (thereby in addition to being a Licensee also
+becoming a Licensor), always provided that he shall:
+a. comply with section 3.1;
+b. cause the modified Documentation to carry prominent notices stating
+that the Licensee has modified the Documentation, with the date and
+details of the modifications;
+c. license the modified Documentation under the terms and conditions
+of this Licence or, where applicable, a later version of this Licence
+as may be issued by CERN; and
+d. send a copy of the modified Documentation to all Licensors that
+contributed to the parts of the Documentation that were modified, as
+well as to any other Licensor who has requested to receive a copy of
+the modified Documentation and has provided a means of contact with
+the Documentation.
+
+3.4 The Licence includes a licence to those patents or registered
+designs that are held by the Licensor, to the extent necessary to make
+use of the rights granted under this Licence. The scope of this
+section 3.4 shall be strictly limited to the parts of the
+Documentation or modified Documentation created by the Licensor.
+
+4. Manufacture and distribution of Products
+
+4.1 The Licensee may manufacture or distribute Products always
+provided that the Licensee distributes to each recipient of such
+Products a copy of the Documentation or modified Documentation, as
+applicable, and complies with section 3.
+
+4.2 The Licensee is invited to inform in writing any Licensor who has
+indicated its wish to receive this information about the type,
+quantity and dates of production of Products the Licensee has (had)
+manufactured.
+
+5. Warranty and liability
+
+5.1 DISCLAIMER – The Documentation and any modified Documentation are
+provided "as is" and any express or implied warranties, including, but
+not limited to, implied warranties of merchantability, of satisfactory
+quality, and fitness for a particular purpose or use are disclaimed in
+respect of the Documentation, the modified Documentation or any
+Product. The Licensor makes no representation that the Documentation,
+modified Documentation, or any Product, does or will not infringe any
+patent, copyright, trade secret or other proprietary right. The entire
+risk as to the use, quality, and performance of a Product shall be
+with the Licensee and not the Licensor. This disclaimer of warranty is
+an essential part of this Licence and a condition for the grant of any
+rights granted under this Licence. The Licensee warrants that it does
+not act in a consumer capacity.
+
+5.2 LIMITATION OF LIABILITY – The Licensor shall have no liability for
+direct, indirect, special, incidental, consequential, exemplary,
+punitive or other damages of any character including, without
+limitation, procurement of substitute goods or services, loss of use,
+data or profits, or business interruption, however caused and on any
+theory of contract, warranty, tort (including negligence), product
+liability or otherwise, arising in any way in relation to the
+Documentation, modified Documentation and/or the use, manufacture or
+distribution of a Product, even if advised of the possibility of such
+damages, and the Licensee shall hold the Licensor(s) free and harmless
+from any liability, costs, damages, fees and expenses, including
+claims by third parties, in relation to such use.
+
+6. General
+
+6.1 The rights granted under this Licence do not imply or represent
+any transfer or assignment of intellectual property rights to the
+Licensee.
+
+6.2 The Licensee shall not use or make reference to any of the names,
+acronyms, images or logos under which the Licensor is known, save in
+so far as required to comply with section 3. Any such permitted use or
+reference shall be factual and shall in no event suggest any kind of
+endorsement by the Licensor or its personnel of the modified
+Documentation or any Product, or any kind of implication by the
+Licensor or its personnel in the preparation of the modified
+Documentation or Product.
+
+6.3 CERN may publish updated versions of this Licence which retain the
+same general provisions as this version, but differ in detail so far
+this is required and reasonable. New versions will be published with a
+unique version number.
+
+6.4 This Licence shall terminate with immediate effect, upon written
+notice and without involvement of a court if the Licensee fails to
+comply with any of its terms and conditions, or if the Licensee
+initiates legal action against Licensor in relation to this
+Licence. Section 5 shall continue to apply.
+
+6.5 Except as may be otherwise agreed with the Intergovernmental
+Organization, any dispute with respect to this Licence involving an
+Intergovernmental Organization shall, by virtue of the latter's
+Intergovernmental status, be settled by international arbitration. The
+arbitration proceedings shall be held at the place where the
+Intergovernmental Organization has its seat. The arbitral award shall
+be final and binding upon the parties, who hereby expressly agree to
+renounce any form of appeal or revision.

--- a/src/main/assembly/dist/lic/CERN-OHL-1.2.txt
+++ b/src/main/assembly/dist/lic/CERN-OHL-1.2.txt
@@ -1,0 +1,189 @@
+CERN Open Hardware Licence v1.2
+
+Preamble
+
+Through this CERN Open Hardware Licence ("CERN OHL") version 1.2, CERN
+wishes to provide a tool to foster collaboration and sharing among
+hardware designers.  The CERN OHL is copyright CERN. Anyone is welcome
+to use the CERN OHL, in unmodified form only, for the distribution of
+their own Open Hardware designs. Any other right is reserved. Release
+of hardware designs under the CERN OHL does not constitute an
+endorsement of the licensor or its designs nor does it imply any
+involvement by CERN in the development of such designs.
+
+1. Definitions
+
+In this Licence, the following terms have the following meanings:
+
+“Licence” means this CERN OHL.
+
+“Documentation” means schematic diagrams, designs, circuit or circuit
+board layouts, mechanical drawings, flow charts and descriptive text,
+and other explanatory material that is explicitly stated as being made
+available under the conditions of this Licence. The Documentation may
+be in any medium, including but not limited to computer files and
+representations on paper, film, or any other media.
+
+“Documentation Location” means a location where the Licensor has
+placed Documentation, and which he believes will be publicly
+accessible for at least three years from the first communication to
+the public or distribution of Documentation.
+
+“Product” means either an entire, or any part of a, device built using
+the Documentation or the modified Documentation.
+
+“Licensee” means any natural or legal person exercising rights under
+this Licence.
+
+“Licensor” means any natural or legal person that creates or modifies
+Documentation and subsequently communicates to the public and/ or
+distributes the resulting Documentation under the terms and conditions
+of this Licence.
+
+A Licensee may at the same time be a Licensor, and vice versa.
+
+Use of the masculine gender includes the feminine and neuter genders
+and is employed solely to facilitate reading.
+
+2. Applicability
+
+2.1. This Licence governs the use, copying, modification,
+communication to the public and distribution of the Documentation, and
+the manufacture and distribution of Products. By exercising any right
+granted under this Licence, the Licensee irrevocably accepts these
+terms and conditions.
+
+2.2. This Licence is granted by the Licensor directly to the Licensee,
+and shall apply worldwide and without limitation in time. The Licensee
+may assign his licence rights or grant sub-licences.
+
+2.3. This Licence does not extend to software, firmware, or code
+loaded into programmable devices which may be used in conjunction with
+the Documentation, the modified Documentation or with Products, unless
+such software, firmware, or code is explicitly expressed to be subject
+to this Licence. The use of such software, firmware, or code is
+otherwise subject to the applicable licence terms and conditions.
+
+3. Copying, modification, communication to the public and distribution
+of the Documentation
+
+3.1. The Licensee shall keep intact all copyright and trademarks
+notices, all notices referring to Documentation Location, and all
+notices that refer to this Licence and to the disclaimer of warranties
+that are included in the Documentation. He shall include a copy
+thereof in every copy of the Documentation or, as the case may be,
+modified Documentation, that he communicates to the public or
+distributes.
+
+3.2. The Licensee may copy, communicate to the public and distribute
+verbatim copies of the Documentation, in any medium, subject to the
+requirements specified in section 3.1.
+
+3.3. The Licensee may modify the Documentation or any portion thereof
+provided that upon modification of the Documentation, the Licensee
+shall make the modified Documentation available from a Documentation
+Location such that it can be easily located by an original Licensor
+once the Licensee communicates to the public or distributes the
+modified Documentation under section 3.4, and, where required by
+section 4.1, by a recipient of a Product. However, the Licensor shall
+not assert his rights under the foregoing proviso unless or until a
+Product is distributed.
+
+3.4. The Licensee may communicate to the public and distribute the
+modified Documentation (thereby in addition to being a Licensee also
+becoming a Licensor), always provided that he shall:
+
+a) comply with section 3.1;
+
+b) cause the modified Documentation to carry prominent notices stating
+that the Licensee has modified the Documentation, with the date and
+description of the modifications;
+
+c) cause the modified Documentation to carry a new Documentation
+Location notice if the original Documentation provided for one;
+
+d) make available the modified Documentation at the same level of
+abstraction as that of the Documentation, in the preferred format for
+making modifications to it (e.g. the native format of the CAD tool as
+applicable), and in the event that format is proprietary, in a format
+viewable with a tool licensed under an OSI-approved license if the
+proprietary tool can create it; and
+
+e) license the modified Documentation under the terms and conditions
+of this Licence or, where applicable, a later version of this Licence
+as may be issued by CERN.
+
+3.5. The Licence includes a non-exclusive licence to those patents or
+registered designs that are held by, under the control of, or
+sub-licensable by the Licensor, to the extent necessary to make use of
+the rights granted under this Licence. The scope of this section 3.5
+shall be strictly limited to the parts of the Documentation or
+modified Documentation created by the Licensor.
+
+4. Manufacture and distribution of Products
+
+4.1. The Licensee may manufacture or distribute Products always
+provided that, where such manufacture or distribution requires a
+licence under this Licence the Licensee provides to each recipient of
+such Products an easy means of accessing a copy of the Documentation
+or modified Documentation, as applicable, as set out in section 3.
+
+4.2. The Licensee is invited to inform any Licensor who has indicated
+his wish to receive this information about the type, quantity and
+dates of production of Products the Licensee has (had) manufactured
+
+5. Warranty and liability
+
+5.1. DISCLAIMER – The Documentation and any modified Documentation are
+provided "as is" and any express or implied warranties, including, but
+not limited to, implied warranties of merchantability, of satisfactory
+quality, non-infringement of third party rights, and fitness for a
+particular purpose or use are disclaimed in respect of the
+Documentation, the modified Documentation or any Product. The Licensor
+makes no representation that the Documentation, modified
+Documentation, or any Product, does or will not infringe any patent,
+copyright, trade secret or other proprietary right. The entire risk as
+to the use, quality, and performance of a Product shall be with the
+Licensee and not the Licensor. This disclaimer of warranty is an
+essential part of this Licence and a condition for the grant of any
+rights granted under this Licence. The Licensee warrants that it does
+not act in a consumer capacity.
+
+5.2. LIMITATION OF LIABILITY – The Licensor shall have no liability
+for direct, indirect, special, incidental, consequential, exemplary,
+punitive or other damages of any character including, without
+limitation, procurement of substitute goods or services, loss of use,
+data or profits, or business interruption, however caused and on any
+theory of contract, warranty, tort (including negligence), product
+liability or otherwise, arising in any way in relation to the
+Documentation, modified Documentation and/or the use, manufacture or
+distribution of a Product, even if advised of the possibility of such
+damages, and the Licensee shall hold the Licensor(s) free and harmless
+from any liability, costs, damages, fees and expenses, including
+claims by third parties, in relation to such use.
+
+6. General
+
+6.1. Except for the rights explicitly granted hereunder, this Licence
+does not imply or represent any transfer or assignment of intellectual
+property rights to the Licensee.
+
+6.2. The Licensee shall not use or make reference to any of the names
+(including acronyms and abbreviations), images, or logos under which
+the Licensor is known, save in so far as required to comply with
+section 3. Any such permitted use or reference shall be factual and
+shall in no event suggest any kind of endorsement by the Licensor or
+its personnel of the modified Documentation or any Product, or any
+kind of implication by the Licensor or its personnel in the
+preparation of the modified Documentation or Product.
+
+6.3. CERN may publish updated versions of this Licence which retain
+the same general provisions as this version, but differ in detail so
+far this is required and reasonable. New versions will be published
+with a unique version number.
+
+6.4. This Licence shall terminate with immediate effect, upon written
+notice and without involvement of a court if the Licensee fails to
+comply with any of its terms and conditions, or if the Licensee
+initiates legal action against Licensor in relation to this
+Licence. Section 5 shall continue to apply.

--- a/src/main/assembly/dist/lic/TAPR-OHL-1.0.txt
+++ b/src/main/assembly/dist/lic/TAPR-OHL-1.0.txt
@@ -1,0 +1,266 @@
+The TAPR Open Hardware License
+Version 1.0 (May 25, 2007)
+Copyright 2007 TAPR - http://www.tapr.org/OHL
+
+PREAMBLE
+
+Open Hardware is a thing - a physical artifact, either electrical or
+mechanical - whose design information is available to, and usable by,
+the public in a way that allows anyone to make, modify, distribute, and
+use that thing.  In this preface, design information is called
+"documentation" and things created from it are called "products."
+
+The TAPR Open Hardware License ("OHL") agreement provides a legal
+framework for Open Hardware projects.  It may be used for any kind of
+product, be it a hammer or a computer motherboard, and is TAPR's
+contribution to the community; anyone may use the OHL for their Open
+Hardware project.
+
+Like the GNU General Public License, the OHL is designed to guarantee
+your freedom to share and to create.  It forbids anyone who receives
+rights under the OHL to deny any other licensee those same rights to
+copy, modify, and distribute documentation, and to make, use and
+distribute products based on that documentation.
+
+Unlike the GPL, the OHL is not primarily a copyright license.  While
+copyright protects documentation from unauthorized copying, modification,
+and distribution, it has little to do with your right to make, distribute,
+or use a product based on that documentation.  For better or worse, patents
+play a significant role in those activities.  Although it does not prohibit
+anyone from patenting inventions embodied in an Open Hardware design, and
+of course cannot prevent a third party from enforcing their patent rights,
+those who benefit from an OHL design may not bring lawsuits claiming that
+design infringes their patents or other intellectual property.
+
+The OHL addresses unique issues involved in the creation of tangible,
+physical things, but does not cover software, firmware, or code loaded
+into programmable devices.  A copyright-oriented license such as the GPL
+better suits these creations.
+
+How can you use the OHL, or a design based upon it?  While the terms and
+conditions below take precedence over this preamble, here is a summary:
+
+*  You may modify the documentation and make products based upon it.
+
+*  You may use products for any legal purpose without limitation.
+
+*  You may distribute unmodified documentation, but you must include the
+complete package as you received it.
+
+*  You may distribute products you make to third parties, if you either
+include the documentation on which the product is based, or make it
+available without charge for at least three years to anyone who requests
+it.
+
+*  You may distribute modified documentation or products based on it, if
+you:
+    *  License your modifications under the OHL.
+    *  Include those modifications, following the requirements stated
+       below.
+    *  Attempt to send the modified documentation by email to any of the
+       developers who have provided their email address.  This is a good
+       faith obligation - if the email fails, you need do nothing more
+       and may go on with your distribution.
+
+*  If you create a design that you want to license under the OHL, you
+should:
+    *  Include this document in a file named LICENSE (with the appropriate
+       extension) that is included in the documentation package.
+    *  If the file format allows, include a notice like "Licensed under
+       the TAPR Open Hardware License (www.tapr.org/OHL)" in each
+       documentation file.  While not required, you should also include
+       this notice on printed circuit board artwork and the product
+       itself; if space is limited the notice can be shortened or
+       abbreviated.
+    *  Include a copyright notice in each file and on printed circuit
+       board artwork.
+    *  If you wish to be notified of modifications that others may make,
+       include your email address in a file named "CONTRIB.TXT" or
+       something similar.
+
+*  Any time the OHL requires you to make documentation available to
+others, you must include all the materials you received from the
+upstream licensors.  In addition, if you have modified the
+documentation:
+    *  You must identify the modifications in a text file (preferably
+       named "CHANGES.TXT") that you include with the documentation.
+       That file must also include a statement like "These modifications
+       are licensed under the TAPR Open Hardware License."
+    *  You must include any new files you created, including any
+       manufacturing files (such as Gerber files) you create in the
+       course of making products.
+    *  You must include both "before" and "after" versions of all files
+       you modified.
+    *  You may include files in proprietary formats, but you must also
+       include open format versions (such as Gerber, ASCII, Postscript,
+       or PDF) if your tools can create them.
+
+TERMS AND CONDITIONS
+
+1.   Introduction
+1.1  This Agreement governs how you may use, copy, modify, and
+distribute Documentation, and how you may make, have made, and
+distribute Products based on that Documentation.  As used in this
+Agreement, to "distribute" Documentation means to directly or indirectly
+make copies available to a third party, and to "distribute" Products
+means to directly or indirectly give, loan, sell or otherwise transfer
+them to a third party.
+
+1.2  "Documentation" includes:
+     (a) schematic diagrams;
+     (b) circuit or circuit board layouts, including Gerber and other
+         data files used for manufacture;
+     (c) mechanical drawings, including CAD, CAM, and other data files
+         used for manufacture;
+     (d) flow charts and descriptive text; and
+     (e) other explanatory material.
+Documentation may be in any tangible or intangible form of expression,
+including but not limited to computer files in open or proprietary
+formats and representations on paper, film, or other media.
+
+1.3  "Products" include:
+     (a) circuit boards, mechanical assemblies, and other physical parts
+         and components;
+     (b) assembled or partially assembled units (including components
+         and subassemblies); and
+     (c) parts and components combined into kits intended for assembly
+         by others;
+which are based in whole or in part on the Documentation.
+
+1.4  This Agreement applies to any Documentation which contains a
+notice stating it is subject to the TAPR Open Hardware License, and to
+all Products based in whole or in part on that Documentation.  If
+Documentation is distributed in an archive (such as a "zip" file) which
+includes this document, all files in that archive are subject to this
+Agreement unless they are specifically excluded.  Each person who
+contributes content to the Documentation is referred to in this
+Agreement as a "Licensor."
+
+1.5  By (a) using, copying, modifying, or distributing the
+Documentation, or (b) making or having Products made or distributing
+them, you accept this Agreement, agree to comply with its terms, and
+become a "Licensee."  Any activity inconsistent with this Agreement will
+automatically terminate your rights under it (including the immunities
+from suit granted in Section 2), but the rights of others who have
+received Documentation, or have obtained Products, directly or
+indirectly from you will not be affected so long as they fully comply
+with it themselves.
+
+1.6  This Agreement does not apply to software, firmware, or code
+loaded into programmable devices which may be used in conjunction with
+Documentation or Products.  Such software is subject to the license
+terms established by its copyright holder(s).
+
+2.   Patents
+2.1  Each Licensor grants you, every other Licensee, and every
+possessor or user of Products a perpetual, worldwide, and royalty-free
+immunity from suit under any patent, patent application, or other
+intellectual property right which he or she controls, to the extent
+necessary to make, have made, possess, use, and distribute Products.
+This immunity does not extend to infringement arising from modifications
+subsequently made by others.
+
+2.2  If you make or have Products made, or distribute Documentation
+that you have modified, you grant every Licensor, every other Licensee,
+and every possessor or user of Products a perpetual, worldwide, and
+royalty-free immunity from suit under any patent, patent application, or
+other intellectual property right which you control, to the extent
+necessary to make, have made, possess, use, and distribute Products.
+This immunity does not extend to infringement arising from modifications
+subsequently made by others.
+
+2.3  To avoid doubt, providing Documentation to a third party for the
+sole purpose of having that party make Products on your behalf is not
+considered "distribution,"\" and a third party's act of making Products
+solely on your behalf does not cause that party to grant the immunity
+described in the preceding paragraph.
+
+2.4  These grants of immunity are a material part of this Agreement,
+and form a portion of the consideration given by each party to the
+other.  If any court judgment or legal agreement prevents you from
+granting the immunity required by this Section, your rights under this
+Agreement will terminate and you may no longer use, copy, modify or
+distribute the Documentation, or make, have made, or distribute
+Products.
+
+3.   Modifications
+You may modify the Documentation, and those modifications will become
+part of the Documentation.  They are subject to this Agreement, as are
+Products based in whole or in part on them.  If you distribute the
+modified Documentation, or Products based in whole or in part upon it,
+you must email the modified Documentation in a form compliant with
+Section 4 to each Licensor who has provided an email address with the
+Documentation.  Attempting to send the email completes your obligations
+under this Section and you need take no further action if any address
+fails.
+
+4.   Distributing Documentation
+4.1  You may distribute unmodified copies of the Documentation in its
+entirety in any medium, provided that you retain all copyright and other
+notices (including references to this Agreement) included by each
+Licensor, and include an unaltered copy of this Agreement.
+4.2  You may distribute modified copies of the Documentation if you
+comply with all the requirements of the preceding paragraph and:
+     (a) include a prominent notice in an ASCII or other open format
+         file identifying those elements of the Documentation that you
+         changed, and stating that the modifications are licensed under
+         the terms of this Agreement;
+     (b) include all new documentation files that you create, as well as
+         both the original and modified versions of each file you change
+         (files may be in your development tool's native file format,
+         but if reasonably possible, you must also include open format,
+         such as Gerber, ASCII, Postscript, or PDF, versions);
+     (c) do not change the terms of this Agreement with respect to
+         subsequent licensees; and
+     (d) if you make or have Products made, include in the Documentation
+         all elements reasonably required to permit others to make
+         Products, including Gerber, CAD/CAM and other files used for
+         manufacture.
+
+5.   Making Products
+5.1  You may use the Documentation to make or have Products made,
+provided that each Product retains any notices included by the Licensor
+(including, but not limited to, copyright notices on circuit boards).
+5.2  You may distribute Products you make or have made, provided that
+you include with each unit a copy of the Documentation in a form
+consistent with Section 4.  Alternatively, you may include either (i) an
+offer valid for at least three years to provide that Documentation, at
+no charge other than the reasonable cost of media and postage, to any
+person who requests it; or (ii) a URL where that Documentation may be
+downloaded, available for at least three years after you last distribute
+the Product.
+
+6.   NEW LICENSE VERSIONS
+TAPR may publish updated versions of the OHL which retain the same
+general provisions as the present version, but differ in detail to
+address new problems or concerns, and carry a distinguishing version
+number.  If the Documentation specifies a version number which applies
+to it and "any later version", you may choose either that version or any
+later version published by TAPR.  If the Documentation does not specify
+a version number, you may choose any version ever published by TAPR.
+TAPR owns the copyright to the OHL, but grants permission to any person
+to copy, distribute, and use it in unmodified form.
+
+7.   WARRANTY AND LIABILITY LIMITATIONS
+7.1  THE DOCUMENTATION IS PROVIDED ON AN"AS-IS" BASIS WITHOUT
+WARRANTY OF ANY KIND, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  ALL
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+TITLE, ARE HEREBY EXPRESSLY DISCLAIMED.
+7.2  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW WILL ANY LICENSOR
+BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, CONSEQUENTIAL, PUNITIVE, OR EXEMPLARY DAMAGES ARISING OUT OF
+THE USE OF, OR INABILITY TO USE, THE DOCUMENTATION OR PRODUCTS,
+INCLUDING BUT NOT LIMITED TO CLAIMS OF INTELLECTUAL PROPERTY
+INFRINGEMENT OR LOSS OF DATA, EVEN IF THAT PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+7.3  You agree that the foregoing limitations are reasonable due to
+the non-financial nature of the transaction represented by this
+Agreement, and acknowledge that were it not for these limitations, the
+Licensor(s) would not be willing to make the Documentation available to
+you.
+7.4  You agree to defend, indemnify, and hold each Licensor harmless
+from any claim brought by a third party alleging any defect in the
+design, manufacture, or operation of any Product which you make, have
+made, or distribute pursuant to this Agreement.
+                                 ####

--- a/src/main/assembly/dist/lic/licenses.properties
+++ b/src/main/assembly/dist/lic/licenses.properties
@@ -1,7 +1,12 @@
-http\://creativecommons.org/publicdomain/zero/1.0/=CC0-1.0.html
+http\://creativecommons.org/publicdomain/zero/1.0=CC0-1.0.html
 http\://creativecommons.org/licenses/by/4.0=CC-BY-4.0.html
 http\://opensource.org/licenses/MIT=MIT.txt
 http\://www.apache.org/licenses/LICENSE-2.0=Apache-2.0.txt
 http\://opensource.org/licenses/BSD-3-Clause=BSD-3-Clause.txt
 http\://opensource.org/licenses/BSD-2-Clause=BSD-2-Clause.txt
 http\://www.gnu.org/licenses/gpl-3.0.en.html=GPL-3.0.html
+http\://creativecommons.org/licenses/by-nc-sa/3.0=BY-NC-SA-3.0.html
+http\://creativecommons.org/licenses/by-nc/3.0=
+http\://www.ohwr.org/attachments/2388/cern_ohl_v_1_2.txt=CERN-OHL-1.2.txt
+http\://www.ohwr.org/attachments/735/CERNOHLv1_1.txt=CERN-OHL-1.1.txt
+http\://www.tapr.org/TAPR_Open_Hardware_License_v1.0.txt=TAPR-OHL-1.0.txt

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
@@ -45,7 +45,6 @@ object AdditionalLicense {
     } yield mime
 
   def getAdditionalLicenseTemplate(ddm: NodeSeq)(implicit s: Settings): Try[(String, MimeType)] = Try {
-
     val licenses = ddm \\ "DDM" \ "dcmiMetadata" \ "license"
     licenses match {
       case Seq(license) =>
@@ -59,20 +58,22 @@ object AdditionalLicense {
   }
 
   /**
-   * Retrieves a matching license, while being liberal in what it excepts:
+   * Retrieves a matching license, while being liberal in what it accepts:
    *
-   * - https is excepted instead of http
+   * - both http and https accepted
    * - a trailing slash is ignored
    *
    * @param uri the URI of the license
    * @param licenses the map from license URI-string to license File
-   * @return
+   * @return the license File if found, otherwise None
    */
   def getMatchingLicense(uri: URI, licenses: Map[String, File]): Option[File] = {
-    val httpUri = {
-      if (uri.getScheme == "https") new URI("http", uri.getUserInfo, uri.getHost, uri.getPort, uri.getPath, uri.getQuery, uri.getFragment)
+    def withScheme(uri: URI, scheme: String) = new URI(scheme, uri.getUserInfo, uri.getHost, uri.getPort, uri.getPath, uri.getQuery, uri.getFragment)
+
+    val httpUri =
+      if (uri.getScheme == "https") withScheme(uri, "https")
       else uri
-    }
+
     licenses.get(httpUri.toASCIIString).orElse {
       if (httpUri.toASCIIString.last == '/') licenses.get(httpUri.toASCIIString.init)
       else None

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage.dataset
 
 import java.io.File
+import java.net.URI
 
 import nl.knaw.dans.easy.stage.dataset.Util.loadBagXML
 import nl.knaw.dans.easy.stage.lib.Constants
@@ -44,15 +45,37 @@ object AdditionalLicense {
     } yield mime
 
   def getAdditionalLicenseTemplate(ddm: NodeSeq)(implicit s: Settings): Try[(String, MimeType)] = Try {
+
     val licenses = ddm \\ "DDM" \ "dcmiMetadata" \ "license"
     licenses match {
       case Seq(license) =>
           if(hasXsiType(license, "http://purl.org/dc/terms/", "URI")) {
-            val licenseTemplateFile = s.licenses(license.text)
+            val licenseTemplateFile = getMatchingLicense(new URI(license.text), s.licenses).getOrElse(throw RejectedDepositException(s"Not a valid license URI: ${license.text}"))
             (FileUtils.readFileToString(licenseTemplateFile, "UTF-8"), getLicenseMimeType(licenseTemplateFile.getName))
           }
           else (license.text, "text/plain")
       case lics => throw RejectedDepositException(s"Found ${lics.size} dcterms:license elements. There should be exactly one")
+    }
+  }
+
+  /**
+   * Retrieves a matching license, while being liberal in what it excepts:
+   *
+   * - https is excepted instead of http
+   * - a trailing slash is ignored
+   *
+   * @param uri the URI of the license
+   * @param licenses the map from license URI-string to license File
+   * @return
+   */
+  def getMatchingLicense(uri: URI, licenses: Map[String, File]): Option[File] = {
+    val httpUri = {
+      if (uri.getScheme == "https") new URI("http", uri.getUserInfo, uri.getHost, uri.getPort, uri.getPath, uri.getQuery, uri.getFragment)
+      else uri
+    }
+    licenses.get(httpUri.toASCIIString).orElse {
+      if (httpUri.toASCIIString.last == '/') licenses.get(httpUri.toASCIIString.init)
+      else None
     }
   }
 


### PR DESCRIPTION
During the test run with Mendeley license URIs were sent that were almost correct, but
used https instead of http. Made the selection of the license file more liberal so that
https instead of http is accepted, and one redundant trailing space is ignored.

@DANS-KNAW/easy 