### PR TITLE
dropped obsolete code, applied a type alias

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/lib/RelationObject.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/lib/RelationObject.scala
@@ -17,6 +17,8 @@ package nl.knaw.dans.easy.stage.lib
 
 import java.io.File
 
+import nl.knaw.dans.easy.stage.FedoraID
+
 sealed abstract class RelationObject(val relationObjectType: RelationObjectType) {
   def tupled: (String, String)
 }
@@ -25,7 +27,7 @@ case class SdoRelationObject(folder: File) extends RelationObject(SdoRelationObj
   override def tupled: (String, String) = (relationObjectType.name, folder.toString)
 }
 
-case class FedoraRelationObject(fedoraId: String) extends RelationObject(FedoraRelationObjectType) {
+case class FedoraRelationObject(fedoraId: FedoraID) extends RelationObject(FedoraRelationObjectType) {
   override def tupled: (String, String) = (relationObjectType.name, s"info:fedora/$fedoraId")
 }
 

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -36,24 +36,6 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers with BeforeAndAfterEa
 
   override def beforeEach(): Unit = deleteQuietly(testDir.toFile)
 
-  "getItemsToStage" should "return list of SDO with parent relations that are internally consistent" in {
-    getItemsToStage(Seq("path", "to", "new", "file.txt"), new File("dataset-sdo-set"), "easy-folder:123") shouldBe
-    Seq(
-      (new File("dataset-sdo-set/path"), "path", FedoraRelationObject("easy-folder:123")),
-      (new File("dataset-sdo-set/path_to"), "path/to", SdoRelationObject(new File("dataset-sdo-set/path"))),
-      (new File("dataset-sdo-set/path_to_new"), "path/to/new", SdoRelationObject(new File("dataset-sdo-set/path_to"))),
-      (new File("dataset-sdo-set/path_to_new_file_txt"), "path/to/new/file.txt", SdoRelationObject(new File("dataset-sdo-set/path_to_new")))
-    )
-  }
-
-  it should "return an empty Seq when given one" in {
-    getItemsToStage(Seq(), new File("dataset-sdo-set"), "easy-folder:123") shouldBe Seq()
-  }
-
-  it should "return only a file item if path contains one element" in {
-    getItemsToStage(Seq("file.txt"), new File("dataset-sdo-set"), "easy-folder:123") shouldBe Seq((new File("dataset-sdo-set/file_txt"), "file.txt", FedoraRelationObject("easy-folder:123")))
-  }
-
   "getSettingsRows" should "create a single row from dummy conf" in {
     // requires a FileItemConf instance with verified arguments
     getSettingsRows(FileItemConf.dummy).get.size shouldBe 1


### PR DESCRIPTION
clean up of code after EASY-1245

#### When applied it will
* drop some obsolete code
* replace String with type alias FedoraID where applicable 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

no functional change

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
