### PR TITLE
Normalization of http:// and https:// licence URLs was broken  

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/AdditionalLicense.scala
@@ -71,7 +71,7 @@ object AdditionalLicense {
     def withScheme(uri: URI, scheme: String) = new URI(scheme, uri.getUserInfo, uri.getHost, uri.getPort, uri.getPath, uri.getQuery, uri.getFragment)
 
     val httpUri =
-      if (uri.getScheme == "https") withScheme(uri, "https")
+      if (uri.getScheme == "https") withScheme(uri, "http")
       else uri
 
     licenses.get(httpUri.toASCIIString).orElse {


### PR DESCRIPTION
by commit 2435e14eba1611b51a1fb748ada4c7f66a6d2da7

