### PR TITLE
EASY-1282: Let the FOXml contain the filename instead of the title for the name of the file

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/fileitem/EasyFileMetadata.scala
@@ -22,7 +22,7 @@ import scala.util.Try
 object EasyFileMetadata {
   def apply(s: FileItemSettings): Try[String] = Try {
       val parentPath = s.pathInDataset.get.getParentFile
-      val fileName = s.title.getOrElse(s.pathInDataset.get.getName)
+      val fileName = s.pathInDataset.get.getName
 
       <fimd:file-item-md xmlns:fimd="http://easy.dans.knaw.nl/easy/file-item-md/" version="0.1" >
         <name>{fileName}</name>

--- a/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/fileitem/EasyStageFileItemSpec.scala
@@ -232,7 +232,7 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers with BeforeAndAfterEa
     } EasyStageFileItem.run(fileItemSettings) shouldBe a[Success[_]]
   }
 
-  "createFileSdo" should "use title (if exactly one provided) instead of file name" in {
+  "createFileSdo" should "use file name even if a title is provided" in {
     val sdoSetDir = new File("target/testSdoSet")
     val sdoDir = new File(sdoSetDir, "path_to_uuid-as-file-name")
     sdoSetDir.mkdirs()
@@ -251,8 +251,8 @@ class EasyStageFileItemSpec extends FlatSpec with Matchers with BeforeAndAfterEa
     EasyStageFileItem.createFileSdo(sdoDir, FedoraRelationObject("ficticiousParentSdo"))
 
     val efmd =  loadXML(new File(sdoDir, "EASY_FILE_METADATA"))
-    (efmd \ "name").text shouldBe "A nice title"
-    (efmd \ "path").text shouldBe "path/to/A nice title"
+    (efmd \ "name").text shouldBe "uuid-as-file-name"
+    (efmd \ "path").text shouldBe "path/to/uuid-as-file-name"
     val foxml = loadXML(new File(sdoDir, "fo.xml"))
     (foxml \ "datastream" \ "datastreamVersion" \ "xmlContent" \ "dc" \ "title").text shouldBe "A nice title"
   }


### PR DESCRIPTION
fixes EASY-1282

#### When applied it will
* no longer use a title as file name
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
