### PR TITLE
EASY-1311: Add archive commandline option, indicating where the data and metadata is archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x 
 SYNOPSIS
 --------
 
-    easy-stage-dataset -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -f <external-file-uris> ] \
+    easy-stage-dataset -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -f <external-file-uris> ] [-a <archive>] \
                               <EASY-deposit> <staged-digital-object-set>
 
     easy-stage-file-item [<options>...] <staged-digital-object-set>
@@ -38,6 +38,10 @@ the command `easy-stage-file-item`. It executes step 3 to stage one or more file
 ARGUMENTS for easy-stage-dataset
 --------------------------------
 
+    -a, --archive  <arg>                The way the dataset is archived. This must be either EASY or DATAVAULT.
+                                        EASY: Data and metadata are archived in EASY. DATAVAULT: Data and
+                                        metadata are archived in the DATAVAULT. There may be dissemination
+                                        copies in EASY. (default = EASY)
     -d, --doi  <arg>                    The DOI to assign to the new dataset in EASY
     -o, --doi-is-other-access-doi       Stage the provided DOI as an "other access DOI"
     -f, --external-file-uris  <arg>     File with mappings from bag local path to external file URI. Each line

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <inceptionYear>2015-2016</inceptionYear>
     <properties>
         <main-class>nl.knaw.dans.easy.stage.EasyStageDataset</main-class>
-        <easy.ddm.version>3.3</easy.ddm.version>
+        <easy.ddm.version>3.4</easy.ddm.version>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>

--- a/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Conf.scala
@@ -39,7 +39,7 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
 
   val description = """Stage a dataset in EASY-BagIt format for ingest into an EASY Fedora Commons 3.x Repository."""
   val synopsis: String =
-    s"""  $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -f <external-file-uris> ] \\
+    s"""  $printedName -t <submission-timestamp> -u <urn> -d <doi> [ -o ] [ -f <external-file-uris> ] [-a <archive>] \\
        |  ${_________}    <EASY-deposit> <staged-digital-object-set>""".stripMargin
   banner(s"""
            |  $description
@@ -76,6 +76,12 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
     name = "state",
     descr = "The state of the dataset to be created. This must be one of DRAFT, SUBMITTED or PUBLISHED.",
     default = Option("DRAFT"))
+  val archive: ScallopOption[String] = opt[String](
+    name = "archive",
+    descr = "The way the dataset is archived. This must be either EASY or DATAVAULT. " +
+            "EASY: Data and metadata are archived in EASY. " +
+            "DATAVAULT: Data and metadata are archived in the DATAVAULT. There may be dissemination copies in EASY.",
+    default = Option("EASY"))
   val deposit: ScallopOption[File] = trailArg[File](
     name = "EASY-deposit",
     descr = "Deposit directory contains deposit.properties file and bag with extra metadata for EASY to be staged for ingest into Fedora",

--- a/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/Settings.scala
@@ -34,6 +34,7 @@ case class Settings(ownerId: String,
                     otherAccessDoi: Boolean = false,
                     fileUris: Map[Path, URI] = Map(),
                     state: String,
+                    archive: String,
                     disciplines: Map[String, String]) {
 
   val licenses: Map[String, File] = Licenses.getLicenses
@@ -51,6 +52,7 @@ object Settings {
             otherAccessDoi: Boolean,
             fileUris: Map[Path, URI],
             state: String,
+            archive: String,
             credentials: FedoraCredentials
            ): Settings = {
     Fedora.setFedoraConnectionSettings(
@@ -68,6 +70,7 @@ object Settings {
       otherAccessDoi = otherAccessDoi,
       fileUris = fileUris,
       state = state,
+      archive = archive,
       disciplines = Fedora.disciplines)
   }
 
@@ -86,6 +89,7 @@ object Settings {
       otherAccessDoi = conf.otherAccessDOI(),
       fileUris = conf.getDsLocationMappings,
       state = conf.state(),
+      archive = conf.archive(),
       disciplines = Fedora.disciplines)
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/stage/dataset/EMD.scala
+++ b/src/main/scala/nl/knaw/dans/easy/stage/dataset/EMD.scala
@@ -24,7 +24,7 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.pf.language.ddm.api.Ddm2EmdCrosswalk
 import nl.knaw.dans.pf.language.emd.EasyMetadata
 import nl.knaw.dans.pf.language.emd.binding.EmdMarshaller
-import nl.knaw.dans.pf.language.emd.types.{ BasicIdentifier, EmdConstants }
+import nl.knaw.dans.pf.language.emd.types.{ BasicIdentifier, EmdArchive, EmdConstants }
 
 import scala.util.{ Failure, Success, Try }
 
@@ -41,6 +41,7 @@ object EMD extends DebugEnhancedLogging {
       _   = s.urn.foreach(urn => emd.getEmdIdentifier.add(wrapUrn(urn)))
       _   = s.doi.foreach(doi => emd.getEmdIdentifier.add(wrapDoi(doi, s.otherAccessDoi)))
       _   = emd.getEmdIdentifier.add(createDmoIdWithPlaceholder())
+      _   = emd.getEmdOther.getEasApplicationSpecific.setArchive(createEmdArchive(s.archive))
           /*
            * DO NOT USE getXmlString !! It will get the XML bytes and convert them to string using the
            * platform's default Charset, which may not be what we expect.
@@ -89,5 +90,12 @@ object EMD extends DebugEnhancedLogging {
     val basicId = new BasicIdentifier(placeholder)
     basicId.setScheme(EmdConstants.SCHEME_DMO_ID)
     basicId
+  }
+
+  def createEmdArchive(archive: String): EmdArchive = {
+    trace(archive)
+    val emdArchive = new EmdArchive();
+    emdArchive.setLocation(EmdArchive.Location.valueOf(archive));
+    emdArchive
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/EasyStageDatasetSpec.scala
@@ -169,6 +169,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers with OneInstancePerTes
       urn = Some("someUrn"),
       doi = Some("doei"),
       state = "DRAFT",
+      archive = "EASY",
       disciplines = Map[String, String](
         "D10000" -> "easy-discipline:57",
         "D30000" -> "easy-discipline:1",

--- a/src/test/scala/nl/knaw/dans/easy/stage/RunSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/RunSpec.scala
@@ -86,6 +86,7 @@ class RunSpec extends FlatSpec with Matchers {
       urn = Some("someUrn"),
       doi = Some("doei"),
       state = "DRAFT",
+      archive = "EASY",
       disciplines = Map[String, String](
         "D10000" -> "easy-discipline:57",
         "D30000" -> "easy-discipline:1",

--- a/src/test/scala/nl/knaw/dans/easy/stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/stage/lib/EmdSpec.scala
@@ -28,7 +28,7 @@ class EmdSpec extends FlatSpec with Matchers {
 
   val sdoSetDir = new File("target/test/EmdSpec/sdoSet")
   def newSettings(bagitDir: File): Settings = {
-    new Settings(ownerId = "", bagitDir = bagitDir, sdoSetDir = sdoSetDir, state = "DRAFT", disciplines = Map[String, String]())
+    new Settings(ownerId = "", bagitDir = bagitDir, sdoSetDir = sdoSetDir, state = "DRAFT", archive = "EASY", disciplines = Map[String, String]())
   }
 
   "create" should "succeed for each test bag" in {


### PR DESCRIPTION
fixes EASY-1311 add archive commandline option, indicating where the data and metadata is archived

#### When applied it will
* support the 'archive' option, defaulting to EASY

- [x] Needs to use an upgraded version of the easy-ddm lib, in turn build with an upgraded version of the easy-emd lib. 

- [x] Web-ui needs to be upgraded to the new emd, otherwise we get an internal error when requesting the dataset that has the 'archived' element in the EMD data stream 

#### Where should the reviewer @DANS-KNAW/easy start?
src/main/scala/nl/knaw/dans/easy/stage/dataset/EMD.scala

#### How should this be manually tested?
When it builds deploy it and run it with the supplied 'medium' test; src/test/resources/deposits/medium
`$ easy-stage-dataset -d testdoi -u testurn -a DATAVAULT medium mediumSDO`
Check in the generated EMD file that it contains 
`<eas:archive eas:location="DATAVAULT"/>`

#### related pull requests on github
repo                       | PR| notes
-------------------------- | -----------------|---------
easy-emd                      | [PR#4](https://github.com/DANS-KNAW/easy-emd/pull/4) | merged and available as v3.2
easy-app| [PR#84](https://github.com/DANS-KNAW/easy-app/pull/84)| update EASY-LIBS