### PR TITLE
Fixed problem with jar filename.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.53</version>
+        <version>1.55</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/main/assembly/dist/bin/easy-stage-dataset
+++ b/src/main/assembly/dist/bin/easy-stage-dataset
@@ -16,4 +16,4 @@ fi
 
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
-     -jar $APPHOME/bin/easy-stage-dataset.jar $@
+     -jar $APPHOME/bin/easy-stage-dataset*.jar $@

--- a/src/main/assembly/dist/bin/easy-stage-file-item
+++ b/src/main/assembly/dist/bin/easy-stage-file-item
@@ -16,5 +16,5 @@ fi
 
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
-     -cp $APPHOME/bin/easy-stage-dataset.jar \
+     -cp $APPHOME/bin/easy-stage-dataset*.jar \
      nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem $@


### PR DESCRIPTION
The filename of the jar built did not include the version number. This led to a mismatch between
the classpath entry in MANIFEST.MF and the actual filename of the library, and subsequently to a
NoClassDefFound error in easy-ingest-flow.

fixes EASY-

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
