### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>
@@ -54,21 +54,16 @@
             <artifactId>commons-csv</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
+            <artifactId>scala-xml_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
-            <artifactId>json4s-native_2.11</artifactId>
-            <version>3.2.11</version>
+            <artifactId>json4s-native_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -129,7 +124,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4-1201-jdbc41</version>
         </dependency>
         <dependency>
             <!-- Necessary to get rid of jodatime warnings about missing FromString
@@ -139,20 +133,19 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>5.0.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/scala/nl.knaw.dans.easy.stage/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/Command.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage
 
 import java.io.File
+import java.nio.file.Paths
 
 import nl.knaw.dans.easy.stage.lib.Fedora
 import nl.knaw.dans.lib.error._
@@ -24,7 +25,7 @@ import org.joda.time.DateTime
 
 object Command extends App {
 
-  val configuration = Configuration()
+  val configuration = Configuration(Paths.get(System.getProperty("app.home")))
   val clo = new CommandLineOptions(args, configuration)
   Fedora.setFedoraConnectionSettings(
     configuration.properties.getString("fcrepo.url"),

--- a/src/main/scala/nl.knaw.dans.easy.stage/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/Configuration.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.stage
 
 import java.io.File
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.commons.configuration.PropertiesConfiguration
 import resource.managed
@@ -28,8 +28,7 @@ case class Configuration(version: String, properties: PropertiesConfiguration, l
 
 object Configuration {
 
-  def apply(): Configuration = {
-    val home = Paths.get(System.getProperty("app.home"))
+  def apply(home: Path): Configuration = {
     val cfgPath = Seq(Paths.get(s"/etc/opt/dans.knaw.nl/easy-stage-dataset/"), home.resolve("cfg"))
       .find(Files.exists(_))
       .getOrElse { throw new IllegalStateException("No configuration directory found") }

--- a/src/main/scala/nl.knaw.dans.easy.stage/fileitem/EasyStageFileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/fileitem/EasyStageFileItem.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage.fileitem
 
 import java.io.File
+import java.nio.file.Paths
 import java.sql.SQLException
 
 import com.yourmediashelf.fedora.client.FedoraClientException
@@ -32,7 +33,7 @@ import scala.util.{ Failure, Success, Try }
 object EasyStageFileItem extends DebugEnhancedLogging {
 
   def main(args: Array[String]) {
-    val configuration = Configuration()
+    val configuration = Configuration(Paths.get(System.getProperty("app.home")))
     val clo = new FileItemCommandLineOptions(args, configuration)
     Fedora.setFedoraConnectionSettings(
       configuration.properties.getString("fcrepo.url"),

--- a/src/main/scala/nl.knaw.dans.easy.stage/lib/CSV.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/lib/CSV.scala
@@ -20,7 +20,7 @@ import java.io.{ File, FileInputStream, InputStream }
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser.parse
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.io.Source.fromInputStream
 import scala.util.{ Failure, Success, Try }
 
@@ -75,6 +75,6 @@ object CSV {
   }
 
   private def getContent(in: InputStream): Try[Seq[Seq[String]]] = Try {
-    parse(fromInputStream(in).mkString, CSVFormat.RFC4180).getRecords.map(_.toList)
+    parse(fromInputStream(in).mkString, CSVFormat.RFC4180).getRecords.asScala.map(_.asScala.toSeq)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.stage/lib/Fedora.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/lib/Fedora.scala
@@ -19,7 +19,7 @@ import com.yourmediashelf.fedora.client.request.FedoraRequest
 import com.yourmediashelf.fedora.client.{ FedoraClient, FedoraCredentials }
 
 import scala.annotation.tailrec
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.xml.XML
 
 trait Fedora {
@@ -47,8 +47,8 @@ object Fedora extends Fedora {
     val objectsResponse = token.map(objectsQuery.sessionToken(_).execute).getOrElse(objectsQuery.execute)
 
     if (objectsResponse.hasNext)
-      findObjects(query, acc ++ objectsResponse.getPids, Some(objectsResponse.getToken))
+      findObjects(query, acc ++ objectsResponse.getPids.asScala, Some(objectsResponse.getToken))
     else
-      acc ++ objectsResponse.getPids
+      acc ++ objectsResponse.getPids.asScala
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
@@ -78,8 +78,7 @@ class RunSpec extends FlatSpec with Matchers with CanConnectFixture {
      * Not the ideal solution, but we need to get the licenses list for this test to work, and it is
      * available in the dist directory.
      */
-    System.setProperty("app.home", "src/main/assembly/dist")
-    val configuration = Configuration()
+    val configuration = Configuration(Paths.get("src/main/assembly/dist"))
 
     // the user and disciplines should exist in deasy
     // to allow ingest and subsequent examination with the web-ui of the generated sdo sets


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* provide a parameter to the `Configuration` constructor

@DANS-KNAW/easy for review