### PR TITLE
EASY-1791 org.fcrepo.server.errors.ObjectValidityException because of long label

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.stage/lib/FOXML.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/lib/FOXML.scala
@@ -64,7 +64,7 @@ object FOXML extends DebugEnhancedLogging {
                          xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
       <foxml:objectProperties>
         <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active" />
-        <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE={label.substring(0, Math.min(label.length, MAX_LABEL_LENGTH))} />
+        <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE={label.substring(0, label.length min MAX_LABEL_LENGTH)} />
         <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE={ownerId} />
       </foxml:objectProperties>
       <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">

--- a/src/main/scala/nl.knaw.dans.easy.stage/lib/FOXML.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/lib/FOXML.scala
@@ -21,6 +21,7 @@ import nl.knaw.dans.pf.language.emd.EasyMetadata
 import scala.xml.{ Elem, NodeSeq, XML }
 
 object FOXML extends DebugEnhancedLogging {
+  private val MAX_LABEL_LENGTH = 255
 
   def getDatasetFOXML(ownerId: String, emd: EasyMetadata): String = {
     trace(ownerId)
@@ -63,7 +64,7 @@ object FOXML extends DebugEnhancedLogging {
                          xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
       <foxml:objectProperties>
         <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active" />
-        <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE={label} />
+        <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE={label.substring(0, Math.min(label.length, MAX_LABEL_LENGTH))} />
         <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE={ownerId} />
       </foxml:objectProperties>
       <foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">


### PR DESCRIPTION
Fixes EASY-1791

#### When applied it will
* Make sure the FOXML label property is truncated to 255 characters, so that Fedora will not generate the ObjectValidityException.

#### Where should the reviewer @DANS-KNAW/easy start?
The one changed file.

#### How should this be manually tested?
See issue description.
