### PR TITLE
EASY-1670 Command-line startup script: argumenten met spaties

### DIFF
--- a/src/main/assembly/dist/bin/easy-stage-dataset
+++ b/src/main/assembly/dist/bin/easy-stage-dataset
@@ -16,4 +16,4 @@ fi
 
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
-     -jar $APPHOME/bin/easy-stage-dataset.jar $@
+     -jar $APPHOME/bin/easy-stage-dataset.jar "$@"

--- a/src/main/assembly/dist/bin/easy-stage-file-item
+++ b/src/main/assembly/dist/bin/easy-stage-file-item
@@ -17,4 +17,4 @@ fi
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
      -cp $APPHOME/bin/easy-stage-dataset.jar \
-     nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem $@
+     nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem "$@"


### PR DESCRIPTION
Fixes EASY-1670

#### When applied
* It is possible to pass parameters containing spaces


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
