### PR TITLE
only log the depositId, not the whole path to the bag

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -69,7 +69,7 @@ object EMD extends DebugEnhancedLogging {
         emd.getEmdRights.setAcceptedLicense(true)
       }
       else {
-        logger.warn(s"[${ s.bagitDir }] agreements.xml did NOT contain a depositAgreementAccepted=true element")
+        logger.warn(s"[${ s.bagitDir.getParentFile.getName }] agreements.xml did NOT contain a depositAgreementAccepted=true element")
       }
       addPrivacySensitiveRemark(emd, agreementsXml)
     }

--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -74,7 +74,7 @@ object EMD extends DebugEnhancedLogging {
       addPrivacySensitiveRemark(emd, agreementsXml)
     }
     else {
-      logger.info(s"[${ s.bagitDir }] agreements.xml not found, not setting agreement data")
+      logger.info(s"[${ s.bagitDir.getParentFile.getName }] agreements.xml not found, not setting agreement data")
     }
   }
 


### PR DESCRIPTION
Currently the log says something like

```
[/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox/90ffe58d-3897-4988-a06f-34a59ad01b0b/584461] agreements.xml not found, not setting agreement data
```

Instead this should be

```
[90ffe58d-3897-4988-a06f-34a59ad01b0b] agreements.xml not found, not setting agreement data
```

@DANS-KNAW/easy for review