### PR TITLE
EASY-2214: Message for Datamanager komt tweemaal in de Remarks

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -102,7 +102,10 @@ object EMD extends DebugEnhancedLogging {
     val msgForDataManager = s.bagitDir.toPath.resolve(depositorInfoDir).resolve("message-from-depositor.txt")
     if (Files.exists(msgForDataManager)) {
       val content = new String(Files.readAllBytes(msgForDataManager), StandardCharsets.UTF_8)
-      emd.getEmdOther.getEasRemarks.add(new BasicRemark(s"Message for the Datamanager: $content"))
+      if (content.isBlank)
+        logger.debug("message-from-depositor.txt was found but was empty, not setting a remark")
+      else
+        emd.getEmdOther.getEasRemarks.add(new BasicRemark(s"Message for the Datamanager: $content"))
     }
     else {
       logger.debug("message-from-depositor.txt not found, not setting a remark")


### PR DESCRIPTION
fixes EASY-2214

#### When applied it will
* check whether `message-from-depositor.txt` file is empty
* if empty the message for Data Manager is not output


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
