### PR TITLE
EASY-2311: add email to Message for the Datamanager

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -81,15 +81,18 @@ object EMD extends DebugEnhancedLogging {
   private def addPrivacySensitiveRemark(emd: EasyMetadata, agreementsXml: Elem): Unit = {
 
     def userNamePart: String = {
-      val signerId = agreementsXml \ "depositAgreement" \ "signerId"
-      (signerId.text, (signerId \@ "easy-account").toOption, (signerId \@ "email").toOption) match {
-        case (fullName, None, None) => fullName
+      val signer = agreementsXml \ "depositAgreement" \ "signerId"
+      val name = signer.text
+      val account = (signer \@ "easy-account").toOption
+      val email = (signer \@ "email").toOption
+      (name, account, email) match {
+        case (name, None, None) => name
         case ("", None, Some(email)) => email
         case ("", Some(account), None) => account
         case ("", Some(account), Some(email)) => s"$account ($email)"
-        case (fullName, None, Some(email)) => s"$fullName ($email)"
-        case (fullName, Some(account), None) => s"$account ($fullName)"
-        case (fullName, Some(account), Some(email)) => s"$account ($fullName, $email)"
+        case (name, None, Some(email)) => s"$name ($email)"
+        case (name, Some(account), None) => s"$name ($account)"
+        case (name, Some(account), Some(email)) => s"$name ($account, $email)"
       }
     }
 
@@ -100,7 +103,7 @@ object EMD extends DebugEnhancedLogging {
 
     val remark = Option((agreementsXml \\ "containsPrivacySensitiveData").text) match {
       case Some(boolText) =>
-        s"according to the depositor $userNamePart this dataset ${ privacyPart(boolText) } contain Privacy Sensitive data."
+        s"According to depositor $userNamePart this dataset ${ privacyPart(boolText) } contain Privacy Sensitive data."
       case None =>
         logger.warn("The field containsPrivacySensitiveData could not be found in agreements.xml")
         "it could not be determined if this dataset does contain Privacy Sensitive data."

--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -84,7 +84,7 @@ object EMD extends DebugEnhancedLogging {
       val signerId = agreementsXml \ "depositAgreement" \ "signerId"
       (signerId.text, (signerId \@ "easy-account").toOption, (signerId \@ "email").toOption) match {
         case (fullName, None, None) => fullName
-        case ("", None, Some(email)) => s"$email"
+        case ("", None, Some(email)) => email
         case ("", Some(account), None) => account
         case ("", Some(account), Some(email)) => s"$account ($email)"
         case (fullName, None, Some(email)) => s"$fullName ($email)"
@@ -93,7 +93,7 @@ object EMD extends DebugEnhancedLogging {
       }
     }
 
-    def privacyPart(boolText: String) = {
+    def privacyPart(boolText: String): String = {
       if (BooleanUtils.toBoolean(boolText)) "DOES"
       else "DOES NOT"
     }

--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -96,18 +96,18 @@ object EMD extends DebugEnhancedLogging {
       }
     }
 
-    def privacyPart(boolText: String): String = {
-      if (BooleanUtils.toBoolean(boolText)) "DOES"
-      else "DOES NOT"
-    }
-
-    val remark = Option((agreementsXml \\ "containsPrivacySensitiveData").text) match {
-      case Some(boolText) =>
-        s"According to depositor $userNamePart this dataset ${ privacyPart(boolText) } contain Privacy Sensitive data."
-      case None =>
+    val remark = (agreementsXml \\ "containsPrivacySensitiveData")
+      .headOption
+      .map(node => BooleanUtils.toBoolean(node.text)) // anything but true/y[es] becomes false
+      .map {
+        case true => "DOES"
+        case false => "DOES NOT"
+      }
+      .map(privacyPart => s"According to depositor $userNamePart this dataset $privacyPart contain Privacy Sensitive data.")
+      .getOrElse {
         logger.warn("The field containsPrivacySensitiveData could not be found in agreements.xml")
         "it could not be determined if this dataset does contain Privacy Sensitive data."
-    }
+      }
 
     emd.getEmdOther.getEasRemarks.add(new BasicRemark(s"Message for the Datamanager: $remark"))
   }

--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -86,8 +86,8 @@ object EMD extends DebugEnhancedLogging {
       val maybeAccount = maybeSigner.flatMap(node => (node \@ "easy-account").toOption)
       val maybeEmail = maybeSigner.flatMap(node => (node \@ "email").toOption)
       (maybeName, maybeAccount, maybeEmail) match {
-        case (None, _, _) =>
-          logger.warn("The field signerId could not be found in agreements.xml")
+        case (None, _, _) | (Some(""), None, None) =>
+          logger.warn("The field signerId in agreements.xml could not be found or has no values")
           "NOT KNOWN"
         case (Some(name), None, None) => name
         case (Some(""), None, Some(email)) => email

--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -79,7 +79,6 @@ object EMD extends DebugEnhancedLogging {
   }
 
   private def addPrivacySensitiveRemark(emd: EasyMetadata, agreementsXml: Elem): Unit = {
-
     val userNamePart = {
       val maybeSigner = (agreementsXml \ "depositAgreement" \ "signerId").headOption
       val maybeName = maybeSigner.map(_.text)

--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -80,7 +80,7 @@ object EMD extends DebugEnhancedLogging {
 
   private def addPrivacySensitiveRemark(emd: EasyMetadata, agreementsXml: Elem): Unit = {
 
-    def userNamePart: String = {
+    val userNamePart = {
       val signer = agreementsXml \ "depositAgreement" \ "signerId"
       val name = signer.text
       val account = (signer \@ "easy-account").toOption
@@ -106,7 +106,7 @@ object EMD extends DebugEnhancedLogging {
       .map(privacyPart => s"According to depositor $userNamePart this dataset $privacyPart contain Privacy Sensitive data.")
       .getOrElse {
         logger.warn("The field containsPrivacySensitiveData could not be found in agreements.xml")
-        "it could not be determined if this dataset does contain Privacy Sensitive data."
+        s"No statement by $userNamePart could be found whether this dataset contains Privacy Sensitive data."
       }
 
     emd.getEmdOther.getEasRemarks.add(new BasicRemark(s"Message for the Datamanager: $remark"))

--- a/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -82,13 +82,13 @@ object EMD extends DebugEnhancedLogging {
 
     def userNamePart: String = {
       val signerId = agreementsXml \ "depositAgreement" \ "signerId"
-      val fullname = signerId.text
+      val fullname = signerId.text // TODO empty string -> causes "(," because of emailPart
       val emailPart = (signerId \@ "email").toOption
-        .map(email => s", <a href='mailto:$email>$email</a>")
+        .map(email => s", $email")
         .getOrElse("")
       val usernamePart = (signerId \@ "easy-account").toOption
-        .map(username => s"$username ($fullname$emailPart)")
-        .getOrElse(s"$fullname$emailPart".trim) // TODO
+        .map(username => s"$username ($fullname$emailPart)".replace("()",""))
+        .getOrElse(s"$fullname$emailPart".trim)
       usernamePart
     }
 

--- a/src/test/resources/dataset-bags/medium/metadata/depositor-info/agreements.xml
+++ b/src/test/resources/dataset-bags/medium/metadata/depositor-info/agreements.xml
@@ -4,7 +4,7 @@
             xmlns:dcterms="http://purl.org/dc/terms/"
             xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
     <depositAgreement>
-        <signerId easy-account="user001">First Namen</signerId>
+        <signerId easy-account="user001" email="does.not.exist@dans.knaw.nl">First Namen</signerId>
         <dcterms:dateAccepted>2019-04-15T16:48:15.640+02:00</dcterms:dateAccepted>
         <depositAgreementAccepted>true</depositAgreementAccepted>
     </depositAgreement>

--- a/src/test/scala/nl.knaw.dans.easy.stage/CanConnectFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/CanConnectFixture.scala
@@ -31,7 +31,7 @@ trait CanConnectFixture {
           connection.connect()
           connection.disconnect()
           true
-        case connection => throw new Exception ("expecting a HttpURLConnection but got " + connection)
+        case connection => throw new Exception("expecting a HttpURLConnection but got " + connection)
       }
     })
   } match {

--- a/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
@@ -77,7 +77,7 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
         emd.getEmdRights.getTermsLicense should contain only (new BasicString("http://opensource.org/licenses/MIT"), acceptBS)
         emd.getEmdOther.getEasRemarks should contain only(
           new BasicRemark("Message for the Datamanager: Beware!!! Very personal data!!!"),
-          new BasicRemark("Message for the Datamanager: according to the depositor user001 (First Namen) this dataset DOES contain Privacy Sensitive data.")
+          new BasicRemark("Message for the Datamanager: according to the depositor user001 (First Namen, <a href='mailto:does.not.exist@dans.knaw.nl>does.not.exist@dans.knaw.nl</a>) this dataset DOES contain Privacy Sensitive data.")
         )
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
@@ -59,7 +59,7 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
     for (bag <- new File("src/test/resources/dataset-bags").listFiles()) {
       sdoSetDir.mkdirs()
       implicit val s: Settings = newSettings(bag)
-      (bag, EMD.create(sdoSetDir)) should matchPattern {
+      (bag, EMD.create(sdoSetDir)) should matchPattern { // TODO use behave like
         case (_, Success(_)) =>
       }
       sdoSetDir.list() shouldBe Array("EMD")
@@ -110,19 +110,14 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
       include("depositor user001 (does.not.exist@dans.knaw.nl) this dataset")
   }
 
-  it should "create a remark for a dataset without sensitive data" in {
-    easRemarksFromAgreements(replacing = "<containsPrivacySensitiveData>true</containsPrivacySensitiveData>", by = "<containsPrivacySensitiveData>false</containsPrivacySensitiveData>") should
+  it should "create a remark for a dataset without privacy sensitive data" in {
+    easRemarksFromAgreements(replacing = "<containsPrivacySensitiveData>true", by = "<containsPrivacySensitiveData>false") should
       include("this dataset DOES NOT contain Privacy Sensitive data")
   }
 
-  it should "create a remark for a dataset with invalid boolean text" in {
-    easRemarksFromAgreements(replacing = "<containsPrivacySensitiveData>true</containsPrivacySensitiveData>", by = "<containsPrivacySensitiveData>rubbish content</containsPrivacySensitiveData>") should
-      include("this dataset DOES NOT contain Privacy Sensitive data")
-  }
-
-  it should "create a remark when no privacy check box is found" in {
+  it should "create a remark without a privacy claim" in {
     easRemarksFromAgreements(replacing = "<containsPrivacySensitiveData>true</containsPrivacySensitiveData>", by = "") should
-      include("Message for the Datamanager: it could not be determined if this dataset does contain Privacy Sensitive data.")
+      include("Message for the Datamanager: No statement by First Namen (user001, does.not.exist@dans.knaw.nl) could be found whether this dataset contains Privacy Sensitive data.")
   }
 
   private def easRemarksFromAgreements(replacing: String, by: String) = {

--- a/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
@@ -78,34 +78,34 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
         emd.getEmdRights.getTermsLicense should contain only(new BasicString("http://opensource.org/licenses/MIT"), acceptBS)
         emd.getEmdOther.getEasRemarks should contain only(
           new BasicRemark("Message for the Datamanager: Beware!!! Very personal data!!!"),
-          new BasicRemark("Message for the Datamanager: according to the depositor user001 (First Namen, does.not.exist@dans.knaw.nl) this dataset DOES contain Privacy Sensitive data.")
+          new BasicRemark("Message for the Datamanager: According to depositor First Namen (user001, does.not.exist@dans.knaw.nl) this dataset DOES contain Privacy Sensitive data.")
         )
     }
   }
 
   it should "create a remark for SignerId without attributes" in {
     easRemarksFrom(agreementsWithout = """( easy-account="user001"| email="does.not.exist@dans.knaw.nl")""") should
-      include("the depositor First Namen this dataset")
+      include("depositor First Namen this dataset")
   }
 
   it should "create a remark for SignerId without email attribute" in {
     easRemarksFrom(agreementsWithout = """( email="does.not.exist@dans.knaw.nl")""") should
-      include("the depositor user001 (First Namen) this dataset")
+      include("depositor First Namen (user001) this dataset")
   }
 
   it should "create a remark for SignerId without account attribute" in {
     easRemarksFrom(agreementsWithout = """( easy-account="user001")""") should
-      include("the depositor First Namen (does.not.exist@dans.knaw.nl) this dataset")
+      include("depositor First Namen (does.not.exist@dans.knaw.nl) this dataset")
   }
 
   it should "create a remark for SignerId with neither email full name" in {
     easRemarksFrom(agreementsWithout = """(First Namen| email="does.not.exist@dans.knaw.nl")""") should
-      include("the depositor user001 this dataset")
+      include("depositor user001 this dataset")
   }
 
   it should "create a remark for SignerId without a full name" in {
     easRemarksFrom(agreementsWithout = "First Namen") should
-      include("the depositor user001 (does.not.exist@dans.knaw.nl) this dataset")
+      include("depositor user001 (does.not.exist@dans.knaw.nl) this dataset")
   }
 
   /**

--- a/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
@@ -120,6 +120,11 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
       include("Message for the Datamanager: No statement by First Namen (user001, does.not.exist@dans.knaw.nl) could be found whether this dataset contains Privacy Sensitive data.")
   }
 
+  it should "create a remark without a signer" in {
+    easRemarksFromAgreements(replacing = """<signerId easy-account="user001" email="does.not.exist@dans.knaw.nl">First Namen</signerId>""", by = "") should
+      include("Message for the Datamanager: No statement by  could be found whether this dataset contains Privacy Sensitive data.")
+  }
+
   private def easRemarksFromAgreements(replacing: String, by: String) = {
     assume(canConnect(xsds))
     sdoSetDir.mkdirs()

--- a/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
@@ -95,21 +95,21 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
 
   it should "create a remark for SignerId without account attribute" in {
     easRemarksFrom(agreementsWithout = """( easy-account="user001")""") should
-      include("the depositor First Namen, does.not.exist@dans.knaw.nl this dataset")
+      include("the depositor First Namen (does.not.exist@dans.knaw.nl) this dataset")
   }
 
   it should "create a remark for SignerId with neither email full name" in {
     easRemarksFrom(agreementsWithout = """(First Namen| email="does.not.exist@dans.knaw.nl")""") should
-      include("the depositor user001  this dataset")
+      include("the depositor user001 this dataset")
   }
 
   it should "create a remark for SignerId without a full name" in {
     easRemarksFrom(agreementsWithout = "First Namen") should
-      include("the depositor user001 (, does.not.exist@dans.knaw.nl) this dataset")
+      include("the depositor user001 (does.not.exist@dans.knaw.nl) this dataset")
   }
 
   /**
-   * @param agreementsWithout a regexp for .replaceAll(..., "")
+   * @param agreementsWithout a regexp, each match is replaced with ""
    * @return EMD.getEmdOther.getEasRemarks.toString
    */
   private def easRemarksFrom(agreementsWithout: String) = {

--- a/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.stage/lib/EmdSpec.scala
@@ -86,17 +86,17 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
   }
 
   it should "create a remark for SignerId without attributes" in {
-    easRemarksFromAgreements(replacing = """( easy-account="user001"| email="does.not.exist@dans.knaw.nl")""", by = "") should
+    easRemarksFromAgreements(replacing = """(easy-account="user001"| email="does.not.exist@dans.knaw.nl")""", by = "") should
       include("depositor First Namen this dataset")
   }
 
   it should "create a remark for SignerId without email attribute" in {
-    easRemarksFromAgreements(replacing = """( email="does.not.exist@dans.knaw.nl")""", by = "") should
+    easRemarksFromAgreements(replacing = """(email="does.not.exist@dans.knaw.nl")""", by = "") should
       include("depositor First Namen (user001) this dataset")
   }
 
   it should "create a remark for SignerId without account attribute" in {
-    easRemarksFromAgreements(replacing = """( easy-account="user001")""", by = "") should
+    easRemarksFromAgreements(replacing = """(easy-account="user001")""", by = "") should
       include("depositor First Namen (does.not.exist@dans.knaw.nl) this dataset")
   }
 
@@ -122,7 +122,12 @@ class EmdSpec extends FlatSpec with Matchers with Inside with CanConnectFixture 
 
   it should "create a remark without a signer" in {
     easRemarksFromAgreements(replacing = """<signerId easy-account="user001" email="does.not.exist@dans.knaw.nl">First Namen</signerId>""", by = "") should
-      include("Message for the Datamanager: No statement by  could be found whether this dataset contains Privacy Sensitive data.")
+      include("Message for the Datamanager: According to depositor NOT KNOWN this dataset DOES contain Privacy Sensitive data.")
+  }
+
+  it should "create a remark without any signer values" in {
+    easRemarksFromAgreements(replacing = """(First Namen|easy-account="user001"| email="does.not.exist@dans.knaw.nl")""", by = "") should
+      include("Message for the Datamanager: According to depositor NOT KNOWN this dataset DOES contain Privacy Sensitive data.")
   }
 
   private def easRemarksFromAgreements(replacing: String, by: String) = {


### PR DESCRIPTION
fixes EASY-2311 : add email to Message for the Datamanager

#### When applied it will
* [x] ~~check if the email href works in the emd when presented by the webui~~
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [x] see https://github.com/DANS-KNAW/easy-deposit-api/pull/181

#### related pull requests on github
to be merged with/after https://github.com/DANS-KNAW/easy-deposit-api/pull/181
which in turn is to be merged after https://github.com/DANS-KNAW/easy-schema/pull/76
