### PR TITLE
NO JIRA. Fix the run*.sh script setup + deploy

### DIFF
--- a/command/debug-init-env.sh
+++ b/command/debug-init-env.sh
@@ -20,7 +20,7 @@ HOMEDIR=home
 DATADIR=data
 
 echo "Copying test data to $DATADIR..."
-cp -r src/test/resources/deposits $DATADIR/deposits
+cp -r ../lib/src/test/resources/dataset-bags $DATADIR/deposits
 
 echo "Copying licenses to $HOMEDIR/cfg..."
 mvn generate-resources

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -140,5 +140,38 @@
                 </plugins>
             </build>
         </profile>
+            <profile>
+                <id>stageDataset</id>
+                <activation>
+                    <activeByDefault>true</activeByDefault>
+                </activation>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>exec-maven-plugin</artifactId>
+                        </plugin>
+                    </plugins>
+                </build>
+            </profile>
+            <profile>
+                <id>stageFileItem</id>
+                <activation>
+                    <property>
+                        <name>stageFileItem</name>
+                    </property>
+                </activation>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>exec-maven-plugin</artifactId>
+                            <configuration>
+                                <mainClass>nl.knaw.dans.easy.stage.command.fileitem.EasyStageFileItemCommand</mainClass>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </profile>
     </profiles>
 </project>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -194,40 +194,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>stageDataset</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>stageFileItem</id>
-            <activation>
-                <property>
-                    <name>stageFileItem</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <configuration>
-                            <mainClass>nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem</mainClass>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
#### When applied it will
* Make sure you can use the `./stageDataset.sh` and `./stageFileItem.sh` scripts for debugging.
* Make sure the `exec-maven-plugin` is *not* included in the `lib`-submodule (which was why the it tried to upload an rpm in the deploy phase, due to the hack that I built in for deploying RPMs to Nexus).

#### Where should the reviewer @DANS-KNAW/easy start?

