### PR TITLE
EASY-2482: include dataset.xml, files.xml (agreements.xml and message-from-depositor.txt) in staged Fedora datastreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,28 +38,30 @@ the command `easy-stage-file-item`. It executes step 3 to stage one or more file
 ARGUMENTS for easy-stage-dataset
 --------------------------------
 
-    -a, --archive  <arg>                The way the dataset is archived. This must be either EASY or DATAVAULT.
-                                        EASY: Data and metadata are archived in EASY. DATAVAULT: Data and
-                                        metadata are archived in the DATAVAULT. There may be dissemination
-                                        copies in EASY. (default = EASY)
-    -d, --doi  <arg>                    The DOI to assign to the new dataset in EASY
-    -o, --doi-is-other-access-doi       Stage the provided DOI as an "other access DOI"
-    -f, --external-file-uris  <arg>     File with mappings from bag local path to external file URI. Each line
-                                        in this file must contain a mapping. The path is separated from the URI
-                                        by one ore more whitespaces. If more groups of whitespaces are
-                                        encountered, they are considered part of the path.
-    -s, --state  <arg>                  The state of the dataset to be created. This must be one of DRAFT,
-                                        SUBMITTED or PUBLISHED. (default = DRAFT)                                      
-    -t, --submission-timestamp  <arg>   Timestamp in ISO8601 format
-    -u, --urn  <arg>                    The URN to assign to the new dataset in EASY
-    -h, --help                          Show help message
-    -v, --version                       Show version of this program
+      -a, --archive  <arg>                The way the dataset is archived. This must be either EASY or DATAVAULT.
+                                          EASY: Data and metadata are archived in EASY. DATAVAULT: Data and
+                                          metadata are archived in the DATAVAULT. There may be dissemination
+                                          copies in EASY. (default = EASY)
+      -d, --doi  <arg>                    The DOI to assign to the new dataset in EASY
+      -o, --doi-is-other-access-doi       Stage the provided DOI as an "other access DOI"
+      -f, --external-file-uris  <arg>     File with mappings from bag local path to external file URI. Each line
+                                          in this file must contain a mapping. The path is separated from the URI
+                                          by one ore more whitespaces. If more groups of whitespaces are
+                                          encountered, they are considered part of the path.
+      -i, --include-bag-metadata          Indicates whether bag metadata (such as dataset.xml and files.xml)
+                                          should be included in the resultant staged digital object.
+      -s, --state  <arg>                  The state of the dataset to be created. This must be one of DRAFT,
+                                          SUBMITTED or PUBLISHED. (default = DRAFT)
+      -t, --submission-timestamp  <arg>   Timestamp in ISO8601 format
+      -u, --urn  <arg>                    The URN to assign to the new dataset in EASY
+      -h, --help                          Show help message
+      -v, --version                       Show version of this program
 
-   trailing arguments:
-    EASY-deposit (required)                Deposit directory contains deposit.properties file and bag with extra
-                                           metadata for EASY to be staged for ingest into Fedora
-    staged-digital-object-set (required)   The resulting Staged Digital Object directory (will be created if it
-                                           does not exist)
+     trailing arguments:
+      EASY-deposit (required)                Deposit directory contains deposit.properties file and bag with extra
+                                             metadata for EASY to be staged for ingest into Fedora
+      staged-digital-object-set (required)   The resulting Staged Digital Object directory (will be created if it
+                                             does not exist)
 
 
 ARGUMENTS

--- a/command/src/main/scala/nl.knaw.dans.easy.stage.command/Command.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.stage.command/Command.scala
@@ -49,7 +49,9 @@ object Command extends App {
     databaseUrl = configuration.properties.getString("db-connection-url"),
     databaseUser = configuration.properties.getString("db-connection-user"),
     databasePassword = configuration.properties.getString("db-connection-password"),
-    licenses = configuration.licenses)
+    licenses = configuration.licenses,
+    includeBagMetadata = clo.includeBagMetadata(),
+  )
 
   EasyStageDataset.run
     .doIfSuccess(_ => println("OK: Completed succesfully"))

--- a/command/src/main/scala/nl.knaw.dans.easy.stage.command/CommandLineOptions.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.stage.command/CommandLineOptions.scala
@@ -81,6 +81,11 @@ class CommandLineOptions(args: Seq[String], configuration: Configuration) extend
       "EASY: Data and metadata are archived in EASY. " +
       "DATAVAULT: Data and metadata are archived in the DATAVAULT. There may be dissemination copies in EASY.",
     default = Option("EASY"))
+  val includeBagMetadata: ScallopOption[Boolean] = opt[Boolean](
+    name = "include-bag-metadata", short = 'i',
+    descr = "Indicates whether bag metadata (such as dataset.xml and files.xml) should be included in the resultant staged digital object.",
+    default = Some(false),
+  )
   val deposit: ScallopOption[File] = trailArg[File](
     name = "EASY-deposit",
     descr = "Deposit directory contains deposit.properties file and bag with extra metadata for EASY to be staged for ingest into Fedora",

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/EasyStageDataset.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/EasyStageDataset.scala
@@ -104,23 +104,21 @@ object EasyStageDataset extends DebugEnhancedLogging {
       _ <- writeAMD(sdoDir, amdContent.toString())
       _ <- writeFoxml(sdoDir, foxmlContent)
       _ <- writePrsql(sdoDir, PRSQL.create())
-      _ <- writeBagMetadata(sdoDir, agreementsXmlExists, messageFromDepositorExists)
+      _ <- if (s.includeBagMetadata) writeBagMetadata(sdoDir, agreementsXmlExists, messageFromDepositorExists)
+           else Success(())
       _ <- writeJsonCfg(sdoDir, jsonCfgContent)
     } yield (emdContent, amdContent) // easy-ingest-flow hands these over to easy-ingest
   }
 
   private def writeBagMetadata(sdoDir: File, agreementsXmlExists: Boolean, messageFromDepositorExists: Boolean)(implicit s: Settings): Try[Unit] = {
-    if (s.includeBagMetadata) {
-      for {
-        _ <- readFile("metadata/dataset.xml").flatMap(writeDatasetXML(sdoDir, _))
-        _ <- readFile("metadata/files.xml").flatMap(writeFilesXML(sdoDir, _))
-        _ <- if (agreementsXmlExists) readFile("metadata/depositor-info/agreements.xml").flatMap(writeAgreementsXML(sdoDir, _))
-             else Success(())
-        _ <- if (messageFromDepositorExists) readFile("metadata/depositor-info/message-from-depositor.txt").flatMap(writeMessageFromDepositor(sdoDir, _))
-             else Success(())
-      } yield ()
-    }
-    else Success(())
+    for {
+      _ <- readFile("metadata/dataset.xml").flatMap(writeDatasetXML(sdoDir, _))
+      _ <- readFile("metadata/files.xml").flatMap(writeFilesXML(sdoDir, _))
+      _ <- if (agreementsXmlExists) readFile("metadata/depositor-info/agreements.xml").flatMap(writeAgreementsXML(sdoDir, _))
+           else Success(())
+      _ <- if (messageFromDepositorExists) readFile("metadata/depositor-info/message-from-depositor.txt").flatMap(writeMessageFromDepositor(sdoDir, _))
+           else Success(())
+    } yield ()
   }
 
   private def readFile(path: String)(implicit s: Settings): Try[String] = {

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/EasyStageDataset.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/EasyStageDataset.scala
@@ -98,26 +98,23 @@ object EasyStageDataset extends DebugEnhancedLogging {
       foxmlContent = getDatasetFOXML(s.ownerId, emdContent)
       additionalLicenseFilenameAndMimeType <- AdditionalLicense.createOptionally(sdoDir)
       audiences <- readAudiences()
-      manifestMd5Exists = new File(s.bagitDir, "manifest-md5.txt").exists()
       manifestSha1Exists = new File(s.bagitDir, "manifest-sha1.txt").exists()
       agreementsXmlExists = new File(s.bagitDir, "metadata/depositor-info/agreements.xml").exists()
       messageFromDepositorExists = new File(s.bagitDir, "metadata/depositor-info/message-from-depositor.txt").exists()
-      jsonCfgContent <- JSON.createDatasetCfg(additionalLicenseFilenameAndMimeType, audiences, manifestMd5Exists, manifestSha1Exists, agreementsXmlExists, messageFromDepositorExists)
+      jsonCfgContent <- JSON.createDatasetCfg(additionalLicenseFilenameAndMimeType, audiences, manifestSha1Exists, agreementsXmlExists, messageFromDepositorExists)
       _ <- writeAMD(sdoDir, amdContent.toString())
       _ <- writeFoxml(sdoDir, foxmlContent)
       _ <- writePrsql(sdoDir, PRSQL.create())
-      _ <- if (s.includeBagMetadata) writeBagMetadata(sdoDir, manifestMd5Exists, manifestSha1Exists, agreementsXmlExists, messageFromDepositorExists)
+      _ <- if (s.includeBagMetadata) writeBagMetadata(sdoDir, manifestSha1Exists, agreementsXmlExists, messageFromDepositorExists)
            else Success(())
       _ <- writeJsonCfg(sdoDir, jsonCfgContent)
     } yield (emdContent, amdContent) // easy-ingest-flow hands these over to easy-ingest
   }
 
-  private def writeBagMetadata(sdoDir: File, manifestMd5Exists: Boolean, manifestSha1Exists: Boolean, agreementsXmlExists: Boolean, messageFromDepositorExists: Boolean)(implicit s: Settings): Try[Unit] = {
+  private def writeBagMetadata(sdoDir: File, manifestSha1Exists: Boolean, agreementsXmlExists: Boolean, messageFromDepositorExists: Boolean)(implicit s: Settings): Try[Unit] = {
     for {
       _ <- readFile("metadata/dataset.xml").flatMap(writeDatasetXML(sdoDir, _))
       _ <- readFile("metadata/files.xml").flatMap(writeFilesXML(sdoDir, _))
-      _ <- if (manifestMd5Exists) readFile("manifest-md5.txt").flatMap(writeMd5Manifest(sdoDir, _))
-           else Success(())
       _ <- if (manifestSha1Exists) readFile("manifest-sha1.txt").flatMap(writeSha1Manifest(sdoDir, _))
            else Success(())
       _ <- if (agreementsXmlExists) readFile("metadata/depositor-info/agreements.xml").flatMap(writeAgreementsXML(sdoDir, _))

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/Settings.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/Settings.scala
@@ -37,13 +37,15 @@ case class Settings(ownerId: String,
                     databaseUrl: String,
                     databaseUser: String,
                     databasePassword: String,
-                    licenses: Map[String, File]) {
+                    licenses: Map[String, File],
+                    includeBagMetadata: Boolean,
+                   ) {
   override def toString: String = {
     s"Stage-Dataset.Settings(ownerId = $ownerId, submissionTimestamp = $submissionTimestamp, " +
       s"bagitDir = $bagitDir, sdoSetDir = $sdoSetDir, urn = ${ urn.getOrElse("<not defined>") }, " +
       s"doi = ${ doi.getOrElse("<not defined>") }, otherAccessDoi = $otherAccessDoi, " +
       s"fileUris = $fileUris, state = $state, archive = $archive, " +
-      s"Database($databaseUrl, $databaseUser, ****))"
+      s"Database($databaseUrl, $databaseUser, ****), licenses = $licenses, includeBagMetadata = $includeBagMetadata)"
   }
 }
 
@@ -64,7 +66,9 @@ object Settings {
             databaseUrl: String,
             databaseUser: String,
             databasePassword: String,
-            licenses: Map[String, File]): Settings = {
+            licenses: Map[String, File],
+            includeBagMetadata: Boolean,
+           ): Settings = {
     Fedora.setFedoraConnectionSettings(
       credentials.getBaseUrl.toString,
       credentials.getUsername,
@@ -85,6 +89,8 @@ object Settings {
       databaseUrl = databaseUrl,
       databaseUser = databaseUser,
       databasePassword = databasePassword,
-      licenses = licenses)
+      licenses = licenses,
+      includeBagMetadata = includeBagMetadata,
+    )
   }
 }

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
@@ -37,6 +37,8 @@ object JSON extends DebugEnhancedLogging {
 
   def createDatasetCfg(additionalLicenseFilenameAndMimetype: Option[(String, String)],
                        audiences: Seq[String],
+                       manifestSha1Exists: Boolean,
+                       manifestMd5Exists: Boolean,
                        agreementsXmlExists: Boolean,
                        messageFromDepositorExists: Boolean,
                       )(implicit s: Settings): Try[String] = Try {
@@ -65,6 +67,24 @@ object JSON extends DebugEnhancedLogging {
             ("mimeType" -> "text/xml"),
         )
 
+        val maybeManifestMd5Entry = manifestMd5Exists
+          .map(_ => {
+            ("contentFile" -> "manifest-md5.txt") ~
+              ("dsId" -> "manifest-md5.txt") ~
+              ("label" -> "Manifest (md5) of the original bag") ~
+              ("controlGroup" -> "M") ~
+              ("mimeType" -> "text/plain")
+          })
+
+        val maybeManifestSha1Entry = manifestSha1Exists
+          .map(_ => {
+            ("contentFile" -> "manifest-sha1.txt") ~
+              ("dsId" -> "manifest-sha1.txt") ~
+              ("label" -> "Manifest (sha1) of the original bag") ~
+              ("controlGroup" -> "M") ~
+              ("mimeType" -> "text/plain")
+          })
+
         val maybeAgreementsXmlEntry = agreementsXmlExists
           .map(_ => {
             ("contentFile" -> "agreements.xml") ~
@@ -83,7 +103,7 @@ object JSON extends DebugEnhancedLogging {
               ("mimeType" -> "text/plain")
           })
 
-        mandatory ++ maybeAgreementsXmlEntry ++ maybeMessageFromDepositorEntry
+        mandatory ++ maybeManifestMd5Entry ++ maybeManifestSha1Entry ++ maybeAgreementsXmlEntry ++ maybeMessageFromDepositorEntry
       })
 
     val additionalLicense = additionalLicenseFilenameAndMimetype

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
@@ -65,7 +65,7 @@ object JSON extends DebugEnhancedLogging {
             ("mimeType" -> "text/xml"),
         )
 
-        val agreementsXmlEntry = agreementsXmlExists
+        val maybeAgreementsXmlEntry = agreementsXmlExists
           .map(_ => {
             ("contentFile" -> "agreements.xml") ~
               ("dsID" -> "agreements.xml") ~
@@ -74,7 +74,7 @@ object JSON extends DebugEnhancedLogging {
               ("mimeType" -> "text/xml")
           })
 
-        val messageFromDepositorEntry = messageFromDepositorExists
+        val maybeMessageFromDepositorEntry = messageFromDepositorExists
           .map(_ => {
             ("contentFile" -> "message-from-depositor.txt") ~
               ("dsID" -> "message-from-depositor.txt") ~
@@ -83,7 +83,7 @@ object JSON extends DebugEnhancedLogging {
               ("mimeType" -> "text/plain")
           })
 
-        mandatory ++ agreementsXmlEntry ++ messageFromDepositorEntry
+        mandatory ++ maybeAgreementsXmlEntry ++ maybeMessageFromDepositorEntry
       })
 
     val additionalLicense = additionalLicenseFilenameAndMimetype

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
@@ -38,7 +38,6 @@ object JSON extends DebugEnhancedLogging {
   def createDatasetCfg(additionalLicenseFilenameAndMimetype: Option[(String, String)],
                        audiences: Seq[String],
                        manifestSha1Exists: Boolean,
-                       manifestMd5Exists: Boolean,
                        agreementsXmlExists: Boolean,
                        messageFromDepositorExists: Boolean,
                       )(implicit s: Settings): Try[String] = Try {
@@ -67,15 +66,6 @@ object JSON extends DebugEnhancedLogging {
             ("mimeType" -> "text/xml"),
         )
 
-        val maybeManifestMd5Entry = manifestMd5Exists
-          .map(_ => {
-            ("contentFile" -> "manifest-md5.txt") ~
-              ("dsId" -> "manifest-md5.txt") ~
-              ("label" -> "Manifest (md5) of the original bag") ~
-              ("controlGroup" -> "M") ~
-              ("mimeType" -> "text/plain")
-          })
-
         val maybeManifestSha1Entry = manifestSha1Exists
           .map(_ => {
             ("contentFile" -> "manifest-sha1.txt") ~
@@ -103,7 +93,7 @@ object JSON extends DebugEnhancedLogging {
               ("mimeType" -> "text/plain")
           })
 
-        mandatory ++ maybeManifestMd5Entry ++ maybeManifestSha1Entry ++ maybeAgreementsXmlEntry ++ maybeMessageFromDepositorEntry
+        mandatory ++ maybeManifestSha1Entry ++ maybeAgreementsXmlEntry ++ maybeMessageFromDepositorEntry
       })
 
     val additionalLicense = additionalLicenseFilenameAndMimetype

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Util.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Util.scala
@@ -68,6 +68,12 @@ object Util extends DebugEnhancedLogging {
   def writeMessageFromDepositor(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "message-from-depositor.txt"), content)
 
+  def writeMd5Manifest(sdoDir: File, content: String): Try[Unit] =
+    writeToFile(new File(sdoDir, "manifest-md5.txt"), content)
+
+  def writeSha1Manifest(sdoDir: File, content: String): Try[Unit] =
+    writeToFile(new File(sdoDir, "manifest-sha1.txt"), content)
+
   def writeFileMetadata(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EASY_FILE_METADATA"), content)
 

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Util.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Util.scala
@@ -68,9 +68,6 @@ object Util extends DebugEnhancedLogging {
   def writeMessageFromDepositor(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "message-from-depositor.txt"), content)
 
-  def writeMd5Manifest(sdoDir: File, content: String): Try[Unit] =
-    writeToFile(new File(sdoDir, "manifest-md5.txt"), content)
-
   def writeSha1Manifest(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "manifest-sha1.txt"), content)
 

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Util.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Util.scala
@@ -56,6 +56,18 @@ object Util extends DebugEnhancedLogging {
   def writeEMD(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EMD"), content)
 
+  def writeDatasetXML(sdoDir: File, content: String): Try[Unit] =
+    writeToFile(new File(sdoDir, "dataset.xml"), content)
+
+  def writeFilesXML(sdoDir: File, content: String): Try[Unit] =
+    writeToFile(new File(sdoDir, "files.xml"), content)
+
+  def writeAgreementsXML(sdoDir: File, content: String): Try[Unit] =
+    writeToFile(new File(sdoDir, "agreements.xml"), content)
+
+  def writeMessageFromDepositor(sdoDir: File, content: String): Try[Unit] =
+    writeToFile(new File(sdoDir, "message-from-depositor.txt"), content)
+
   def writeFileMetadata(sdoDir: File, content: String): Try[Unit] =
     writeToFile(new File(sdoDir, "EASY_FILE_METADATA"), content)
 

--- a/lib/src/test/resources/dataset-bags/minimal/metadata/files.xml
+++ b/lib/src/test/resources/dataset-bags/minimal/metadata/files.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files xmlns:dcterms="http://purl.org/dc/terms/">
+    <file filepath="data/README.md">
+        <dcterms:format>text/plain</dcterms:format>
+    </file>
+    <file filepath="data/random images/image01.png">
+        <dcterms:title>The first image</dcterms:title>
+        <dcterms:description>This description will be archived, but not displayed anywhere in the Web-UI</dcterms:description>
+        <dcterms:format>image/png</dcterms:format>
+        <dcterms:created>2016-11-11</dcterms:created>
+    </file>
+    <file filepath="data/random images/image02.jpeg">
+        <dcterms:format>image/jpeg</dcterms:format>
+        <dcterms:created>2016-11-10</dcterms:created>
+    </file>
+    <file filepath="data/random images/image03.jpeg">
+        <dcterms:format>image/jpeg</dcterms:format>
+        <dcterms:created>2016-11-10</dcterms:created>
+    </file>
+    <file filepath="data/a/deeper/path/With some file.txt">
+        <dcterms:format>text/plain</dcterms:format>
+        <dcterms:created>2016-11-09</dcterms:created>
+    </file>
+</files>
+

--- a/lib/src/test/resources/dataset-bags/minimal/tagmanifest-md5.txt
+++ b/lib/src/test/resources/dataset-bags/minimal/tagmanifest-md5.txt
@@ -1,4 +1,5 @@
 942ba7828f6ce720570e57e985e7ac5c  bag-info.txt
 68b329da9893e34099c7d8ad5cb9c940  manifest-md5.txt
 c568da9b91bdba8059316c423fad0e5e  metadata/dataset.xml
+dedc8afe0337e5e9c3d0158e2d16bb83  metadata/files.xml
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/EasyStageDatasetSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/EasyStageDatasetSpec.scala
@@ -198,6 +198,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers with OneInstancePerTes
       databaseUser = "",
       databasePassword = "",
       licenses = Map.empty,
+      includeBagMetadata = false,
     )
   }
 }

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
@@ -108,6 +108,7 @@ class RunSpec extends FlatSpec with Matchers with CanConnectFixture {
       databaseUser = "",
       databasePassword = "", // TODO: probably not the value in the actual deasy environment
       licenses = licensesMap,
+      includeBagMetadata = true,
     )
   }
 }

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
@@ -65,7 +65,6 @@ class RunSpec extends FlatSpec with Matchers with CanConnectFixture {
       sdoSetDir.resolve("dataset/PRSQL").toFile should exist
     }
 
-    puddingsDir.resolve("medium/dataset/manifest-md5.txt").toFile should exist
     puddingsDir.resolve("medium/dataset/manifest-sha1.txt").toFile should exist
     puddingsDir.resolve("medium/dataset/agreements.xml").toFile should exist
     puddingsDir.resolve("medium/dataset/message-from-depositor.txt").toFile should exist

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
@@ -58,10 +58,15 @@ class RunSpec extends FlatSpec with Matchers with CanConnectFixture {
       res shouldBe a[Success[_]]
       sdoSetDir.resolve("dataset/EMD").toFile should exist
       sdoSetDir.resolve("dataset/AMD").toFile should exist
+      sdoSetDir.resolve("dataset/dataset.xml").toFile should exist
+      sdoSetDir.resolve("dataset/files.xml").toFile should exist
       sdoSetDir.resolve("dataset/cfg.json").toFile should exist
       sdoSetDir.resolve("dataset/fo.xml").toFile should exist
       sdoSetDir.resolve("dataset/PRSQL").toFile should exist
     }
+
+    puddingsDir.resolve("medium/dataset/agreements.xml").toFile should exist
+    puddingsDir.resolve("medium/dataset/message-from-depositor.txt").toFile should exist
 
     numberOfFilesInDir(puddingsDir.resolve("minimal")) shouldBe 1
     numberOfFilesInDir(puddingsDir.resolve("no-additional-license")) shouldBe 5

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
@@ -65,6 +65,8 @@ class RunSpec extends FlatSpec with Matchers with CanConnectFixture {
       sdoSetDir.resolve("dataset/PRSQL").toFile should exist
     }
 
+    puddingsDir.resolve("medium/dataset/manifest-md5.txt").toFile should exist
+    puddingsDir.resolve("medium/dataset/manifest-sha1.txt").toFile should exist
     puddingsDir.resolve("medium/dataset/agreements.xml").toFile should exist
     puddingsDir.resolve("medium/dataset/message-from-depositor.txt").toFile should exist
 

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/MdFixture.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/MdFixture.scala
@@ -43,6 +43,7 @@ class MdFixture extends FlatSpec with Matchers with Inside with CanConnectFixtur
       databaseUser = "",
       databasePassword = "",
       licenses = Map.empty,
+      includeBagMetadata = false,
     )
   }
 


### PR DESCRIPTION
fixes EASY-2482

#### When applied it will
* include `dataset.xml`, `files.xml` (`manifest-sha1.txt`, `agreements.xml` and `message-from-depositor.txt` if present) in staged Fedora datastreams

@DANS-KNAW/easy for review

#### Remark on testing
I tested this on deasy with both a dataset via `easy-sword2` (without the `agreements.xml` and `message-from-depositor.txt` files) and a dataset via `easy-deposit-api` (including `agreements.xml` and `message-from-depositor.txt`). In both instances the files showed up as datastreams in the fedora dataset.
**\<edit>** later we decided to not include these streams when the dataset comes from `easy-sword2`; see https://github.com/DANS-KNAW/easy-ingest-flow/pull/131. In the end, these datastreams are only added when the dataset comes from `easy-deposit-api`.

See also https://github.com/DANS-KNAW/easy-ingest-flow/pull/131