### PR TITLE
EASY-2479 Deposit with main folder called 'dataset' fails

### DIFF
--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/fileitem/FileItemSettings.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/fileitem/FileItemSettings.scala
@@ -20,7 +20,7 @@ import java.net.URL
 
 import nl.knaw.dans.easy.stage.fileitem.FileAccessRights.UserCategory
 import nl.knaw.dans.easy.stage.fileitem.FileItemSettings._
-import nl.knaw.dans.easy.stage.lib.{ Fedora, FedoraRelationObject, RelationObject, SdoRelationObject }
+import nl.knaw.dans.easy.stage.lib.{ Constants, Fedora, FedoraRelationObject, RelationObject, SdoRelationObject }
 import resource.{ ManagedResource, _ }
 
 case class FileItemSettings(sdoSetDir: Option[File],
@@ -41,7 +41,7 @@ case class FileItemSettings(sdoSetDir: Option[File],
                             fedora: Fedora = Fedora,
                             easyFilesAndFolders: EasyFilesAndFolders,
 
-                            subordinate: RelationObject = SdoRelationObject(new File("dataset"))) {
+                            subordinate: RelationObject = SdoRelationObject(new File(Constants.DATASET_SDO))) {
   require(FileItemSettings.creatorRoles.contains(creatorRole), s"illegal value for creatorRole, got $creatorRole")
 }
 

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Constants.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/Constants.scala
@@ -16,6 +16,6 @@
 package nl.knaw.dans.easy.stage.lib
 
 object Constants {
-  val DATASET_SDO = "dataset"
+  val DATASET_SDO = "DATASET_SDO~~RESERVED"
   val ADDITIONAL_LICENSE = "ADDITIONAL_LICENSE"
 }

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
@@ -23,6 +23,7 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
 import org.scalatest.{ FlatSpec, Matchers }
 import resource._
+import Constants.DATASET_SDO
 
 import scala.collection.JavaConverters._
 import scala.util.Success
@@ -57,24 +58,24 @@ class RunSpec extends FlatSpec with Matchers with CanConnectFixture {
       val res = EasyStageDataset.run(settings)
       res.recover { case e => e.printStackTrace() }
       res shouldBe a[Success[_]]
-      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/EMD").toFile should exist
-      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/AMD").toFile should exist
-      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/dataset.xml").toFile should exist
-      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/files.xml").toFile should exist
-      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/cfg.json").toFile should exist
-      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/fo.xml").toFile should exist
-      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/PRSQL").toFile should exist
+      sdoSetDir.resolve(s"$DATASET_SDO/EMD").toFile should exist
+      sdoSetDir.resolve(s"$DATASET_SDO/AMD").toFile should exist
+      sdoSetDir.resolve(s"$DATASET_SDO/dataset.xml").toFile should exist
+      sdoSetDir.resolve(s"$DATASET_SDO/files.xml").toFile should exist
+      sdoSetDir.resolve(s"$DATASET_SDO/cfg.json").toFile should exist
+      sdoSetDir.resolve(s"$DATASET_SDO/fo.xml").toFile should exist
+      sdoSetDir.resolve(s"$DATASET_SDO/PRSQL").toFile should exist
     }
 
-    puddingsDir.resolve(s"medium/${Constants.DATASET_SDO}/manifest-sha1.txt").toFile should exist
-    puddingsDir.resolve(s"medium/${Constants.DATASET_SDO}/agreements.xml").toFile should exist
-    puddingsDir.resolve(s"medium/${Constants.DATASET_SDO}/message-from-depositor.txt").toFile should exist
+    puddingsDir.resolve(s"medium/$DATASET_SDO/manifest-sha1.txt").toFile should exist
+    puddingsDir.resolve(s"medium/$DATASET_SDO/agreements.xml").toFile should exist
+    puddingsDir.resolve(s"medium/$DATASET_SDO/message-from-depositor.txt").toFile should exist
 
     numberOfFilesInDir(puddingsDir.resolve("minimal")) shouldBe 1
     numberOfFilesInDir(puddingsDir.resolve("no-additional-license")) shouldBe 5
     numberOfFilesInDir(puddingsDir.resolve("additional-license-by-text")) shouldBe 5
     numberOfFilesInDir(puddingsDir.resolve("one-invalid-sha1")) shouldBe 5
-    FileUtils.readFileToString(puddingsDir.resolve(s"one-invalid-sha1/${Constants.DATASET_SDO}/EMD").toFile, "UTF-8") should include("planetoïde")
+    FileUtils.readFileToString(puddingsDir.resolve(s"one-invalid-sha1/$DATASET_SDO/EMD").toFile, "UTF-8") should include("planetoïde")
   }
 
   private def numberOfFilesInDir(dir: Path): Int = {

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/RunSpec.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.stage
 import java.io.File
 import java.nio.file.{ Files, Path, Paths }
 
+import nl.knaw.dans.easy.stage.lib.Constants
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
 import org.scalatest.{ FlatSpec, Matchers }
@@ -56,24 +57,24 @@ class RunSpec extends FlatSpec with Matchers with CanConnectFixture {
       val res = EasyStageDataset.run(settings)
       res.recover { case e => e.printStackTrace() }
       res shouldBe a[Success[_]]
-      sdoSetDir.resolve("dataset/EMD").toFile should exist
-      sdoSetDir.resolve("dataset/AMD").toFile should exist
-      sdoSetDir.resolve("dataset/dataset.xml").toFile should exist
-      sdoSetDir.resolve("dataset/files.xml").toFile should exist
-      sdoSetDir.resolve("dataset/cfg.json").toFile should exist
-      sdoSetDir.resolve("dataset/fo.xml").toFile should exist
-      sdoSetDir.resolve("dataset/PRSQL").toFile should exist
+      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/EMD").toFile should exist
+      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/AMD").toFile should exist
+      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/dataset.xml").toFile should exist
+      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/files.xml").toFile should exist
+      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/cfg.json").toFile should exist
+      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/fo.xml").toFile should exist
+      sdoSetDir.resolve(s"${Constants.DATASET_SDO}/PRSQL").toFile should exist
     }
 
-    puddingsDir.resolve("medium/dataset/manifest-sha1.txt").toFile should exist
-    puddingsDir.resolve("medium/dataset/agreements.xml").toFile should exist
-    puddingsDir.resolve("medium/dataset/message-from-depositor.txt").toFile should exist
+    puddingsDir.resolve(s"medium/${Constants.DATASET_SDO}/manifest-sha1.txt").toFile should exist
+    puddingsDir.resolve(s"medium/${Constants.DATASET_SDO}/agreements.xml").toFile should exist
+    puddingsDir.resolve(s"medium/${Constants.DATASET_SDO}/message-from-depositor.txt").toFile should exist
 
     numberOfFilesInDir(puddingsDir.resolve("minimal")) shouldBe 1
     numberOfFilesInDir(puddingsDir.resolve("no-additional-license")) shouldBe 5
     numberOfFilesInDir(puddingsDir.resolve("additional-license-by-text")) shouldBe 5
     numberOfFilesInDir(puddingsDir.resolve("one-invalid-sha1")) shouldBe 5
-    FileUtils.readFileToString(puddingsDir.resolve("one-invalid-sha1/dataset/EMD").toFile, "UTF-8") should include("planetoïde")
+    FileUtils.readFileToString(puddingsDir.resolve(s"one-invalid-sha1/${Constants.DATASET_SDO}/EMD").toFile, "UTF-8") should include("planetoïde")
   }
 
   private def numberOfFilesInDir(dir: Path): Int = {


### PR DESCRIPTION
Fixes EASY-2479

#### When applied it will
* `easy-stage-dataset` will call the SDO for the dataset `DATASET_SDO~~RESERVED`. Chances that this name will be used accidently are slim. This is not a watertight solution, but it will do for this legacy module.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
Run a test deposit through `easy-ingest-flow` and follow the logs.
