### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/command/pom.xml
+++ b/command/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath />
     </parent>
 

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath />
     </parent>
 

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/command/src/test/scala/nl.knaw.dans.easy.stage.command/CustomMatchers.scala
+++ b/command/src/test/scala/nl.knaw.dans.easy.stage.command/CustomMatchers.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 
 import org.apache.commons.io.FileUtils._
 import org.scalatest.matchers.{ MatchResult, Matcher }
@@ -28,7 +29,7 @@ trait CustomMatchers {
       def trimLines(s: String): String = s.split("\n").map(_.trim).mkString("\n")
 
       MatchResult(
-        trimLines(readFileToString(left)).contains(trimLines(content)),
+        trimLines(readFileToString(left, StandardCharsets.UTF_8)).contains(trimLines(content)),
         s"$left did not contain: $content",
         s"$left contains $content"
       )

--- a/command/src/test/scala/nl.knaw.dans.easy.stage.command/fileitem/EasyStageFileItemCommandSpec.scala
+++ b/command/src/test/scala/nl.knaw.dans.easy.stage.command/fileitem/EasyStageFileItemCommandSpec.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.stage.command.fileitem
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 
 import nl.knaw.dans.easy.stage.ExistingAncestor
@@ -81,12 +82,13 @@ class EasyStageFileItemCommandSpec extends FlatSpec with Matchers with Inside wi
   }
 
   it should "not overwrite files with same names if folders don't yet exist" in {
-    write(testDir.resolve("to-be-staged/data/some.txt").toFile, "")
-    write(testDir.resolve("to-be-staged/some.txt").toFile, "")
+    write(testDir.resolve("to-be-staged/data/some.txt").toFile, "", StandardCharsets.UTF_8)
+    write(testDir.resolve("to-be-staged/some.txt").toFile, "", StandardCharsets.UTF_8)
     write(testDir.resolve("to-be-staged/some.csv").toFile,
       s"""DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID,FILE-LOCATION
          |easy-dataset:1,8521,text/plain,"data/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/data/some.txt"
-         |easy-dataset:1,8585,text/plain,"some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/some.txt"""".stripMargin)
+         |easy-dataset:1,8585,text/plain,"some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/some.txt"""".stripMargin,
+      StandardCharsets.UTF_8)
 
     runForEachCsvRow(mockEasyFilesAndFolders(HashMap(
       "easy-dataset:1 data/some.txt" -> Success("", "easy-folder:1"),
@@ -96,12 +98,13 @@ class EasyStageFileItemCommandSpec extends FlatSpec with Matchers with Inside wi
   }
 
   it should "not overwrite folders with same names if the parents don't yet exist" in {
-    write(testDir.resolve("to-be-staged/parent/child/some.txt").toFile, "")
-    write(testDir.resolve("to-be-staged/child/some.txt").toFile, "hello")
+    write(testDir.resolve("to-be-staged/parent/child/some.txt").toFile, "", StandardCharsets.UTF_8)
+    write(testDir.resolve("to-be-staged/child/some.txt").toFile, "hello", StandardCharsets.UTF_8)
     write(testDir.resolve("to-be-staged/some.csv").toFile,
       s"""DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID,FILE-LOCATION
          |easy-dataset:1,8521,text/plain,"parent/child/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/parent/child/some.txt"
-         |easy-dataset:1,8585,text/plain,"child/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/child/some.txt"""".stripMargin)
+         |easy-dataset:1,8585,text/plain,"child/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/child/some.txt"""".stripMargin,
+      StandardCharsets.UTF_8)
 
     runForEachCsvRow(mockEasyFilesAndFolders(HashMap(
       "easy-dataset:1 parent" -> Success("", "easy-dataset:1"),
@@ -148,12 +151,13 @@ class EasyStageFileItemCommandSpec extends FlatSpec with Matchers with Inside wi
   }
 
   it should "not overwrite files with same names in root and sub folder" in {
-    write(testDir.resolve("to-be-staged/da/ta/some.txt").toFile, "")
-    write(testDir.resolve("to-be-staged/some.txt").toFile, "")
+    write(testDir.resolve("to-be-staged/da/ta/some.txt").toFile, "", StandardCharsets.UTF_8)
+    write(testDir.resolve("to-be-staged/some.txt").toFile, "", StandardCharsets.UTF_8)
     write(testDir.resolve("to-be-staged/some.csv").toFile,
       s"""DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID,FILE-LOCATION
          |easy-dataset:1,8521,text/plain,"da/ta/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/da/ta/some.txt"
-         |easy-dataset:1,8585,text/plain,"some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/some.txt"""".stripMargin)
+         |easy-dataset:1,8585,text/plain,"some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/some.txt"""".stripMargin,
+      StandardCharsets.UTF_8)
 
     runForEachCsvRow(mockEasyFilesAndFolders(HashMap(
       "easy-dataset:1 da/ta/some.txt" -> Success("da/ta", "easy-folder:1"),
@@ -163,12 +167,13 @@ class EasyStageFileItemCommandSpec extends FlatSpec with Matchers with Inside wi
   }
 
   it should "not overwrite files with same names in sibling folders" in {
-    write(testDir.resolve("to-be-staged/dir1/some.txt").toFile, "")
-    write(testDir.resolve("to-be-staged/dir2/some.txt").toFile, "")
+    write(testDir.resolve("to-be-staged/dir1/some.txt").toFile, "", StandardCharsets.UTF_8)
+    write(testDir.resolve("to-be-staged/dir2/some.txt").toFile, "", StandardCharsets.UTF_8)
     write(testDir.resolve("to-be-staged/some.csv").toFile,
       s"""DATASET-ID,SIZE,FORMAT,PATH-IN-DATASET,DATASTREAM-LOCATION,ACCESSIBLE-TO,VISIBLE-TO,CREATOR-ROLE,OWNER-ID,FILE-LOCATION
          |easy-dataset:1,8521,text/plain,"dir1/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/dir1/some.txt"
-         |easy-dataset:1,8585,text/plain,"dir2/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/dir2/some.txt"""".stripMargin)
+         |easy-dataset:1,8585,text/plain,"dir2/some.txt",,KNOWN,ANONYMOUS,ARCHIVIST,archie001,"$testDir/to-be-staged/dir2/some.txt"""".stripMargin,
+      StandardCharsets.UTF_8)
 
     runForEachCsvRow(mockEasyFilesAndFolders(HashMap(
       "easy-dataset:1 dir1/some.txt" -> Success("dir1", "easy-folder:1"),

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath />
     </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath />
     </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -36,6 +36,8 @@
     <properties>
         <easy.ddm.version>3.10.2</easy.ddm.version>
         <easy.licenses.version>1.0.6</easy.licenses.version>
+        <dom4j.version>20040902.021138</dom4j.version>
+        <dans-fedora.version>3.1.7</dans-fedora.version>
     </properties>
 
     <dependencies>
@@ -78,7 +80,7 @@
             -->
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>20040902.021138</version>
+            <version>${dom4j.version}</version>
             <exclusions>
                 <!--
                 Without this exclusion we get java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal
@@ -97,7 +99,7 @@
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>dans-fedora</artifactId>
-            <version>3.1.7</version>
+            <version>${dans-fedora.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <easy.ddm.version>3.10.3</easy.ddm.version>
         <easy.licenses.version>1.0.6</easy.licenses.version>
-        <dom4j.version>20040902.021138</dom4j.version>
+        <dom4j.version>1.6.1</dom4j.version>
         <dans-fedora.version>3.1.7</dans-fedora.version>
     </properties>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -78,7 +78,7 @@
             -->
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
+            <version>20040902.021138</version>
             <exclusions>
                 <!--
                 Without this exclusion we get java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/EasyStageDataset.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/EasyStageDataset.scala
@@ -143,7 +143,7 @@ object EasyStageDataset extends DebugEnhancedLogging {
     val maybeSha1Map: Try[Map[String, String]] = Try {
       val sha1File = "manifest-sha1.txt"
       readFileToString(new File(s.bagitDir, sha1File), "UTF-8")
-        .lines.filter(_.nonEmpty)
+        .linesIterator.filter(_.nonEmpty)
         .map(_.split("\\h+", 2)) // split into tokens on sequences of horizontal white space characters
         .map {
           case Array(sha1, filePath) if !sha1.matches("[a-fA-F0-9]") => filePath -> sha1

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/dataset/AdditionalLicense.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/dataset/AdditionalLicense.scala
@@ -115,7 +115,7 @@ object AdditionalLicense extends DebugEnhancedLogging {
   }
 
   private def readAndReplace(licenseTemplateFile: File, rightsHolder: String, year: String): String = {
-    FileUtils.readFileToString(licenseTemplateFile)
+    FileUtils.readFileToString(licenseTemplateFile, StandardCharsets.UTF_8)
       .replace("<rightsHolder>", rightsHolder)
       .replace("<year>", year)
   }

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/EasyStageDatasetSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/EasyStageDatasetSpec.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.stage
 
 import java.io.File
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths }
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
@@ -65,7 +66,7 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers with OneInstancePerTes
     val sdoSetDir = testDir.resolve("someSDO")
     implicit val s: Settings = createSettings(bagDir.toFile, sdoSetDir.toFile)
     Files.createDirectories(dataDir)
-    FileUtils.write(bagDir.resolve("manifest-sha1.txt").toFile, "a b c")
+    FileUtils.write(bagDir.resolve("manifest-sha1.txt").toFile, "a b c", StandardCharsets.UTF_8)
 
     inside(createFileAndFolderSdos(dataDir.toFile, DATASET_SDO, ANONYMOUS_ACCESS)) {
       case Failure(e) => e should have message "Invalid line in manifest-sha1.txt: a b c"
@@ -85,12 +86,12 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers with OneInstancePerTes
     // Note that files.xml specifies no accessRights for data/quicksort.hs
 
     createFileAndFolderSdos(dataDir.toFile, DATASET_SDO, OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe a[Success[_]]
-    readFileToString(fileMetadataFile.toFile) should include("<visibleTo>ANONYMOUS</visibleTo>")
-    readFileToString(fileMetadataFile.toFile) should include("<accessibleTo>KNOWN</accessibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<visibleTo>ANONYMOUS</visibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<accessibleTo>KNOWN</accessibleTo>")
 
     createFileAndFolderSdos(dataDir.toFile, DATASET_SDO, ANONYMOUS_ACCESS) shouldBe a[Success[_]]
-    readFileToString(fileMetadataFile.toFile) should include("<visibleTo>ANONYMOUS</visibleTo>")
-    readFileToString(fileMetadataFile.toFile) should include("<accessibleTo>ANONYMOUS</accessibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<visibleTo>ANONYMOUS</visibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<accessibleTo>ANONYMOUS</accessibleTo>")
   }
 
   it should "override default dataset rights when rights are explicitly specified for a file" in {
@@ -104,12 +105,12 @@ class EasyStageDatasetSpec extends FlatSpec with Matchers with OneInstancePerTes
     // Note that files.xml specifies NONE for data/path/to/file.txt
 
     createFileAndFolderSdos(dataDir.toFile, DATASET_SDO, OPEN_ACCESS_FOR_REGISTERED_USERS) shouldBe a[Success[_]]
-    readFileToString(fileMetadataFile.toFile) should include("<visibleTo>ANONYMOUS</visibleTo>")
-    readFileToString(fileMetadataFile.toFile) should include("<accessibleTo>NONE</accessibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<visibleTo>ANONYMOUS</visibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<accessibleTo>NONE</accessibleTo>")
 
     createFileAndFolderSdos(dataDir.toFile, DATASET_SDO, ANONYMOUS_ACCESS) shouldBe a[Success[_]]
-    readFileToString(fileMetadataFile.toFile) should include("<visibleTo>ANONYMOUS</visibleTo>")
-    readFileToString(fileMetadataFile.toFile) should include("<accessibleTo>NONE</accessibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<visibleTo>ANONYMOUS</visibleTo>")
+    readFileToString(fileMetadataFile.toFile, StandardCharsets.UTF_8) should include("<accessibleTo>NONE</accessibleTo>")
   }
 
   "bag with secret file" should "have the correct visibleTo and accessibleTo keywords" in {

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/DepositorInfoSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/DepositorInfoSpec.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage.dataset
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 
 import org.apache.commons.io.FileUtils
 
@@ -39,7 +40,7 @@ class DepositorInfoSpec extends MdFixture {
 
   it should "handle invalid agreements.xml" in {
     infoDir.mkdirs()
-    FileUtils.write(new File(infoDir + "/agreements.xml"), "blablabla")
+    FileUtils.write(new File(infoDir + "/agreements.xml"), "blablabla", StandardCharsets.UTF_8)
     DepositorInfo(infoDir.toPath) shouldBe
       DepositorInfo(
         acceptedLicense = None,
@@ -50,7 +51,7 @@ class DepositorInfoSpec extends MdFixture {
 
   it should "escape the content of message-from-depositor.txt" in {
     infoDir.mkdirs()
-    FileUtils.write(new File(infoDir + "/message-from-depositor.txt"), "blab<br>labla")
+    FileUtils.write(new File(infoDir + "/message-from-depositor.txt"), "blab<br>labla", StandardCharsets.UTF_8)
     DepositorInfo(infoDir.toPath) should matchPattern {
       case DepositorInfo(_, _, "blab&lt;br&gt;labla") =>
     }
@@ -111,7 +112,8 @@ class DepositorInfoSpec extends MdFixture {
       val agreementsFile = new File(infoDir + "/agreements.xml")
       FileUtils.write(
         agreementsFile,
-        FileUtils.readFileToString(agreementsFile).replaceAll(replacing, by)
+        FileUtils.readFileToString(agreementsFile, StandardCharsets.UTF_8).replaceAll(replacing, by),
+        StandardCharsets.UTF_8
       )
     }
     DepositorInfo(infoDir.toPath)

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/EmdSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/EmdSpec.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.stage.dataset
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 
 import nl.knaw.dans.easy.stage._
 import nl.knaw.dans.pf.language.emd.EasyMetadata
@@ -83,7 +84,7 @@ class EmdSpec extends MdFixture with Inspectors {
       </ddm:profile>
     </ddm:DDM>
     val tmpDDM = new File("target/test/EmdSpec/bag/metadata/dataset.xml")
-    write(tmpDDM, ddm.toString())
+    write(tmpDDM, ddm.toString(), StandardCharsets.UTF_8)
     implicit val s: Settings = newSettings(tmpDDM.getParentFile.getParentFile)
 
     inside(EMD.create(sdoSetDir, licenseAccepted = Some(true))) {

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -47,7 +46,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* move unique dependency versions that aren't included in a parent POM to properties
* change `lines.toList` to `linesIterator.toList` due to https://github.com/scala/bug/issues/11125

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 