### PR TITLE
EASY-2164: Zet uit MDB geëxtraheerde CSV's in datasets

### DIFF
--- a/command/src/main/assembly/dist/bin/easy-stage-file-item
+++ b/command/src/main/assembly/dist/bin/easy-stage-file-item
@@ -17,4 +17,4 @@ fi
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
      -cp $APPHOME/bin/easy-stage-dataset.jar \
-     nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem "$@"
+     nl.knaw.dans.easy.stage.command.fileitem.EasyStageFileItemCommand "$@"


### PR DESCRIPTION
fixes EASY-2164

#### When applied it will
* Correct `easy-stage-file-item` bash script


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
