### PR TITLE
NO JIRA ISSUE: fixed duplication in documentation

### DIFF
--- a/command/src/main/assembly/dist/bin/easy-stage-file-item
+++ b/command/src/main/assembly/dist/bin/easy-stage-file-item
@@ -17,4 +17,4 @@ fi
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
      -cp $APPHOME/bin/easy-stage-dataset.jar \
-     nl.knaw.dans.easy.stage.command.fileitem.EasyStageFileItemCommand "$@"
+     nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem "$@"

--- a/command/src/main/assembly/dist/bin/easy-stage-file-item
+++ b/command/src/main/assembly/dist/bin/easy-stage-file-item
@@ -17,4 +17,4 @@ fi
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
      -cp $APPHOME/bin/easy-stage-dataset.jar \
-     nl.knaw.dans.easy.stage.fileitem.EasyStageFileItem "$@"
+     nl.knaw.dans.easy.stage.command.fileitem.EasyStageFileItemCommand "$@"

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,32 +79,22 @@ ARGUMENTS for easy-stage-fileItem
     -f, --format  <arg>                dcterms property format, the mime type of the file
   
     -a, --accessible-to  <arg>         specifies the accessibility of the file item; one of: ANONYMOUS, KNOWN,
-                                     RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = NONE)
+                                       RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = NONE)
     -c, --creator-role  <arg>          specifies the role of the file item creator; one of: ARCHIVIST, DEPOSITOR
-                                     (default = DEPOSITOR)
-      --csv-file  <arg>              a comma separated file with one column for each option (additional
-                                     columns are ignored) and one set of options per line
-    -i, --dataset-id  <arg>            id of the dataset in Fedora that should receive the file to stage
-                                     (requires file-path). If omitted the trailing argument csv-file is
-                                     required
-    -d, --datastream-location  <arg>   http URL to redirect to (if specified, file-location MUST NOT be
-                                     specified)
+                                       (default = DEPOSITOR)
+        --csv-file  <arg>              a comma separated file with one column for each option (additional
+                                       columns are ignored) and one set of options per line
     -l, --file-location  <arg>         The file to be staged (if specified, --datastream-location is ignored)
-    -f, --format  <arg>                dcterms property format, the mime type of the file
-      --owner-id  <arg>              specifies the id of the owner/creator of the file item (defaults to the
-                                     one configured in the application configuration file)
-    -p, --path-in-dataset  <arg>       the path that the file should get in the dataset, a staged digital object
-                                     is created for the file and the ancestor folders that don't yet exist in
-                                     the dataset
-    -s, --size  <arg>                  Size in bytes of the file data
+        --owner-id  <arg>              specifies the id of the owner/creator of the file item (defaults to the
+                                       one configured in the application configuration file)
     -v, --visible-to  <arg>            specifies the visibility of the file item; one of: ANONYMOUS, KNOWN,
-                                     RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = ANONYMOUS)
+                                       RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = ANONYMOUS)
     -h, --help                         Show help message
         --version                      Show version of this program
-    
+  
     trailing arguments:
-    staged-digital-object-sets (required)   The resulting directory with Staged Digital Object directories per
-                                          dataset (will be created if it does not exist)
+     staged-digital-object-sets (required)   The resulting directory with Staged Digital Object directories per
+                                             dataset (will be created if it does not exist)
 
 INSTALLATION AND CONFIGURATION
 ------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,31 +67,30 @@ ARGUMENTS for easy-stage-dataset
 ARGUMENTS for easy-stage-fileItem
 ---------------------------------
 
-    -i, --dataset-id  <arg>            id of the dataset in Fedora that should receive the file to stage
-                                       (requires file-path). If omitted the trailing argument csv-file is
-                                       required
-    -d, --datastream-location  <arg>   http URL to redirect to (if specified, file-location MUST NOT be
-                                       specified)
-    -p, --path-in-dataset  <arg>       the path that the file should get in the dataset, a staged digital object
-                                       is created for the file and the ancestor folders that don't yet exist in
-                                       the dataset
-    -s, --size  <arg>                  Size in bytes of the file data
-    -f, --format  <arg>                dcterms property format, the mime type of the file
-  
-    -a, --accessible-to  <arg>         specifies the accessibility of the file item; one of: ANONYMOUS, KNOWN,
-                                       RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = NONE)
-    -c, --creator-role  <arg>          specifies the role of the file item creator; one of: ARCHIVIST, DEPOSITOR
-                                       (default = DEPOSITOR)
-        --csv-file  <arg>              a comma separated file with one column for each option (additional
-                                       columns are ignored) and one set of options per line
-    -l, --file-location  <arg>         The file to be staged (if specified, --datastream-location is ignored)
-        --owner-id  <arg>              specifies the id of the owner/creator of the file item (defaults to the
-                                       one configured in the application configuration file)
-    -v, --visible-to  <arg>            specifies the visibility of the file item; one of: ANONYMOUS, KNOWN,
-                                       RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = ANONYMOUS)
-    -h, --help                         Show help message
-        --version                      Show version of this program
-  
+     -a, --accessible-to  <arg>         specifies the accessibility of the file item; one of: ANONYMOUS, KNOWN,
+                                        RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = NONE)
+     -c, --creator-role  <arg>          specifies the role of the file item creator; one of: ARCHIVIST, DEPOSITOR
+                                        (default = DEPOSITOR)
+         --csv-file  <arg>              a comma separated file with one column for each option (additional
+                                        columns are ignored) and one set of options per line
+     -i, --dataset-id  <arg>            id of the dataset in Fedora that should receive the file to stage
+                                        (requires file-path). If omitted the trailing argument csv-file is
+                                        required
+     -d, --datastream-location  <arg>   http URL to redirect to (if specified, file-location MUST NOT be
+                                        specified)
+     -l, --file-location  <arg>         The file to be staged (if specified, --datastream-location is ignored)
+     -f, --format  <arg>                dcterms property format, the mime type of the file
+         --owner-id  <arg>              specifies the id of the owner/creator of the file item (defaults to the
+                                        one configured in the application configuration file)
+     -p, --path-in-dataset  <arg>       the path that the file should get in the dataset, a staged digital object
+                                        is created for the file and the ancestor folders that don't yet exist in
+                                        the dataset
+     -s, --size  <arg>                  Size in bytes of the file data
+     -v, --visible-to  <arg>            specifies the visibility of the file item; one of: ANONYMOUS, KNOWN,
+                                        RESTRICTED_REQUEST, RESTRICTED_GROUP, NONE (default = ANONYMOUS)
+     -h, --help                         Show help message
+         --version                      Show version of this program
+    
     trailing arguments:
      staged-digital-object-sets (required)   The resulting directory with Staged Digital Object directories per
                                              dataset (will be created if it does not exist)

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,8 @@ ARGUMENTS for easy-stage-dataset
                                              does not exist)
 
 
-ARGUMENTS
----------
+ARGUMENTS for easy-stage-fileItem
+---------------------------------
 
     -i, --dataset-id  <arg>            id of the dataset in Fedora that should receive the file to stage
                                        (requires file-path). If omitted the trailing argument csv-file is


### PR DESCRIPTION
fixes EASY-

#### When applied it will
* fixed command `easy-stae-file-item`
* Fixed documentation
* [x] add ReadmeSpecs for both modules (it would have kept more of the documentation up to date)
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
