### PR TITLE
EASY-2771: DC schema requires explicit agent

### DIFF
--- a/command/src/main/assembly/dist/cfg/application.properties
+++ b/command/src/main/assembly/dist/cfg/application.properties
@@ -4,3 +4,8 @@ fcrepo.password=changeme
 db-connection-url=jdbc:postgresql://localhost:5432/easy_db
 db-connection-user=easy_webui
 db-connection-password=easy_webui
+
+#
+# User-Agent header used for http requests (such as retrieval of XSD schemas).
+# when omitted the default value will be easy-validate-dans-bag/<version>
+# http.agent=easy-validate-dans-bag

--- a/command/src/main/scala/nl.knaw.dans.easy.stage.command/Command.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.stage.command/Command.scala
@@ -22,12 +22,16 @@ import nl.knaw.dans.easy.stage.lib.Fedora
 import nl.knaw.dans.lib.error._
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.joda.time.DateTime
+import nl.knaw.dans.easy.stage.{ EasyStageDataset, Settings }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import nl.knaw.dans.easy.stage.{ Settings, EasyStageDataset }
-
-object Command extends App {
+object Command extends App with DebugEnhancedLogging {
 
   val configuration = Configuration(Paths.get(System.getProperty("app.home")))
+  val agent = configuration.properties.getString("http.agent",s"easy-stage-dataset/${configuration.version}")
+  logger.info(s"setting http.agent to $agent")
+  System.setProperty("http.agent", agent)
+
   val clo = new CommandLineOptions(args, configuration)
   Fedora.setFedoraConnectionSettings(
     configuration.properties.getString("fcrepo.url"),

--- a/command/src/main/scala/nl.knaw.dans.easy.stage.command/Command.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.stage.command/Command.scala
@@ -28,9 +28,6 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 object Command extends App with DebugEnhancedLogging {
 
   val configuration = Configuration(Paths.get(System.getProperty("app.home")))
-  val agent = configuration.properties.getString("http.agent",s"easy-stage-dataset/${configuration.version}")
-  logger.info(s"setting http.agent to $agent")
-  System.setProperty("http.agent", agent)
 
   val clo = new CommandLineOptions(args, configuration)
   Fedora.setFedoraConnectionSettings(

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/CanConnectFixture.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/CanConnectFixture.scala
@@ -27,6 +27,9 @@ import scala.xml.SAXParseException
 
 trait CanConnectFixture {
 
+  // Some (XSD) servers will deny requests if the User-Agent is set to the default value for Java
+  System.setProperty("http.agent", "Test")
+
   def canConnect(urls: Array[String]): Boolean = urls
     .forall(url => isAvailable(loadSchema(url)))
 

--- a/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/EmdSpec.scala
+++ b/lib/src/test/scala/nl.knaw.dans.easy.stage/dataset/EmdSpec.scala
@@ -27,6 +27,7 @@ import org.scalatest.Inspectors
 import scala.util.{ Failure, Success }
 
 class EmdSpec extends MdFixture with Inspectors {
+  System.setProperty("http.agent", "Test")
 
   "create" should "succeed for each test bag" in {
     assume(canConnect(xsds))


### PR DESCRIPTION
fixes EASY-2771: DC schema requires explicit agent

#### When applied it will
* do `System.setProperty("http.agent",...)` at startup
* [x] move new code to Configuration class
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
See https://github.com/DANS-KNAW/easy-ingest-flow/pull/148
