### PR TITLE
EASY-2823: SUBMITTED datasets komen in de PMH output terecht

### DIFF
--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/lib/JSON.scala
@@ -134,6 +134,11 @@ object JSON extends DebugEnhancedLogging {
     val maybeDoi: List[JObject] = if (s.doi.isEmpty) List[JObject]()
                                   else List(("predicate" -> HAS_DOI) ~ ("object" -> s.doi) ~ ("isLiteral" -> true))
 
+    val maybeOaiMembers =
+      if (s.state == "PUBLISHED")
+        audiences.flatMap(audience => List(("predicate" -> IS_MEMBER_OF_OAI_SET) ~ ("object" -> s"info:fedora/${ s.disciplines(audience) }")))
+      else List.empty[JObject]
+
     ("namespace" -> "easy-dataset") ~
       ("datastreams" -> datastreams) ~
       ("relations" -> (maybeDoi ++ List(
@@ -143,8 +148,8 @@ object JSON extends DebugEnhancedLogging {
         ("predicate" -> HAS_MODEL) ~ ("object" -> "info:fedora/easy-model:oai-item1"),
         ("predicate" -> OAI_ITEM_ID) ~ ("object" -> "oai:easy.dans.knaw.nl:$sdo-id") ~ ("isLiteral" -> true)
       ) ++ audiences.flatMap(audience => List(
-        ("predicate" -> IS_MEMBER_OF) ~ ("object" -> s"info:fedora/${ s.disciplines(audience) }"),
-        ("predicate" -> IS_MEMBER_OF_OAI_SET) ~ ("object" -> s"info:fedora/${ s.disciplines(audience) }")))))
+        ("predicate" -> IS_MEMBER_OF) ~ ("object" -> s"info:fedora/${ s.disciplines(audience) }")))
+        ++ maybeOaiMembers))
   }
 
   def createFileCfg(mimeType: String, parent: RelationObject, subordinate: RelationObject)(implicit settings: FileItemSettings): String = {


### PR DESCRIPTION
fixes EASY-2823

#### When applied
* `Is Member of OAI Set` relation added only when state is `PUBLISHED`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
