### PR TITLE
EASY-2853: Add explanation about 0 files to NoAccess datasets in Fedora

### DIFF
--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/Settings.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/Settings.scala
@@ -42,6 +42,7 @@ import java.nio.file.Path
  * @param licenses
  * @param includeBagMetadata
  * @param skipPayload when no doi is provided payloads are skipped anyway
+ * @param extraDescription
  */
 case class Settings(ownerId: String,
                     submissionTimestamp: DateTime = DateTime.now,
@@ -60,13 +61,15 @@ case class Settings(ownerId: String,
                     licenses: Map[String, File],
                     includeBagMetadata: Boolean,
                     skipPayload: Boolean,
+                    extraDescription: Option[String] = None,
                    ) {
   override def toString: String = {
     s"Stage-Dataset.Settings(ownerId = $ownerId, submissionTimestamp = $submissionTimestamp, " +
       s"bagitDir = $bagitDir, sdoSetDir = $sdoSetDir, urn = ${ urn.getOrElse("<not defined>") }, " +
       s"doi = ${ doi.getOrElse("<not defined>") }, otherAccessDoi = $otherAccessDoi, " +
       s"fileUris = $fileUris, state = $state, archive = $archive, " +
-      s"Database($databaseUrl, $databaseUser, ****), licenses = $licenses, includeBagMetadata = $includeBagMetadata)"
+      s"Database($databaseUrl, $databaseUser, ****), licenses = $licenses, includeBagMetadata = $includeBagMetadata, " +
+      s"skipPayload = $skipPayload, extraDescription = $extraDescription)"
   }
 }
 
@@ -90,6 +93,7 @@ object Settings {
             licenses: Map[String, File],
             includeBagMetadata: Boolean,
             skipPayload: Boolean,
+            extraDescription: Option[String],
            ): Settings = {
     Fedora.setFedoraConnectionSettings(
       credentials.getBaseUrl.toString,
@@ -114,6 +118,7 @@ object Settings {
       licenses = licenses,
       includeBagMetadata = includeBagMetadata,
       skipPayload = skipPayload,
+      extraDescription = extraDescription,
     )
   }
 }

--- a/lib/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.stage/dataset/EMD.scala
@@ -36,6 +36,7 @@ object EMD extends DebugEnhancedLogging {
       case file if file.exists() =>
         for {
           emd <- getEasyMetadata(file)
+          _ = if (s.skipPayload) addExtraDescription(emd)
           _ = s.urn.foreach(urn => emd.getEmdIdentifier.add(wrapUrn(urn)))
           _ = s.doi.foreach(doi => emd.getEmdIdentifier.add(wrapDoi(doi, s.otherAccessDoi)))
           _ = emd.getEmdIdentifier.add(createDmoIdWithPlaceholder())
@@ -51,6 +52,11 @@ object EMD extends DebugEnhancedLogging {
         } yield emd
       case _ => Failure(new RuntimeException(s"Couldn't find metadata/dataset.xml"))
     }
+  }
+
+  private def addExtraDescription(emd: EasyMetadata)(implicit s: Settings): Try[Unit] = Try {
+    trace(emd)
+    s.extraDescription.foreach(d => emd.getEmdDescription.getDcDescription.add(new BasicIdentifier(d)))
   }
 
   private def getEasyMetadata(ddm: File): Try[EasyMetadata] = {


### PR DESCRIPTION
fixes EASY-2853

#### When applied it will
* add `extra paragraph` into `description` when `skipPayload=true`


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-ingest-flow                      | [PR#157](https://github.com/DANS-KNAW/easy-ingest-flow/pull/157) 
